### PR TITLE
Fix example for GraphQL/ArgumentDescription

### DIFF
--- a/lib/rubocop/cop/graphql/argument_description.rb
+++ b/lib/rubocop/cop/graphql/argument_description.rb
@@ -9,13 +9,13 @@ module RuboCop
       #   # good
       #
       #   class BanUser < BaseMutation
-      #     argument :uuid, ID, required: true
+      #     argument :uuid, ID, required: true, description: "UUID of the user to ban"
       #   end
       #
       #   # bad
       #
       #   class BanUser < BaseMutation
-      #     argument :uuid, ID, required: true, description: "UUID of the user to ban"
+      #     argument :uuid, ID, required: true
       #   end
       #
       class ArgumentDescription < Cop


### PR DESCRIPTION
Hi! I just checked this awesome gem and found that one of the examples is telling the opposite of what the cop does.