### PR TITLE
Gracefully handle fields/arguments without kwargs

### DIFF
--- a/lib/rubocop/graphql/field/kwargs.rb
+++ b/lib/rubocop/graphql/field/kwargs.rb
@@ -36,7 +36,7 @@ module RuboCop
         PATTERN
 
         def initialize(field_node)
-          @nodes = field_kwargs(field_node)
+          @nodes = field_kwargs(field_node) || []
         end
 
         def resolver

--- a/spec/rubocop/cop/graphql/field_definitions_spec.rb
+++ b/spec/rubocop/cop/graphql/field_definitions_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldDefinitions do
       end
     end
 
+    context "when field has no kwargs" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :first_name, ID
+          end
+        RUBY
+      end
+    end
+
     context "when field has block" do
       it "not registers an offense" do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
While the graphql gem requires certain kwargs (like `required` or `null`), this prevents errors while Rubocop is analyzing them.