### PR TITLE
Fix NodePattern for fields without a name

### DIFF
--- a/lib/rubocop/graphql/node_pattern.rb
+++ b/lib/rubocop/graphql/node_pattern.rb
@@ -6,18 +6,18 @@ module RuboCop
       extend RuboCop::NodePattern::Macros
 
       def_node_matcher :field_definition?, <<~PATTERN
-        (send nil? :field ...)
+        (send nil? :field (:sym _) ...)
       PATTERN
 
       def_node_matcher :field_definition_with_body?, <<~PATTERN
         (block
-          (send nil? :field ...)
+          (send nil? :field (:sym _) ...)
           ...
         )
       PATTERN
 
       def_node_matcher :argument?, <<~PATTERN
-        (send nil? :argument ...)
+        (send nil? :argument (:sym _) ...)
       PATTERN
 
       def field?(node)

--- a/spec/rubocop/cop/graphql/field_name_spec.rb
+++ b/spec/rubocop/cop/graphql/field_name_spec.rb
@@ -15,6 +15,28 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldName do
     end
   end
 
+  context "when field is called on an extension" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class MyExtension < GraphQL::Schema::FieldExtension
+          def apply
+            field.argument(:width, Integer, required: false)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when field has no name" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class UserType < BaseType
+          field field: MyField
+        end
+      RUBY
+    end
+  end
+
   context "when field name is in camel case" do
     it "registers an offense" do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
`field` can be called without a position name argument which causes errors right now. This also happens when FieldExtension's are used; methods are called on `field` instead of passing arguments.

The simplest fix was to ensure the node pattern matching for field definitions required a symbol positional argument (the field name).