### PR TITLE
Support type classes nested in modules

### DIFF
--- a/lib/rubocop/graphql/field.rb
+++ b/lib/rubocop/graphql/field.rb
@@ -69,7 +69,7 @@ module RuboCop
       end
 
       def root_node?(node)
-        node.parent.nil? || root_with_siblings?(node.parent)
+        node.parent.nil? || node.parent.module_type? || root_with_siblings?(node.parent)
       end
 
       def root_with_siblings?(node)

--- a/spec/rubocop/cop/graphql/field_definitions_spec.rb
+++ b/spec/rubocop/cop/graphql/field_definitions_spec.rb
@@ -269,6 +269,46 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldDefinitions do
         RUBY
       end
 
+      it "registers offenses when type classes are nested within a module" do
+        expect_offense(<<~RUBY)
+          module Types
+            class UserType < BaseType
+              field :first_name, String, null: true
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Define resolver method after field definition.
+              field :last_name, String, null: true
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Define resolver method after field definition.
+
+              def first_name
+                object.contact_data.first_name
+              end
+
+              def last_name
+                object.contact_data.last_name
+              end
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          module Types
+            class UserType < BaseType
+
+              field :first_name, String, null: true
+
+              def first_name
+                object.contact_data.first_name
+              end
+
+              field :last_name, String, null: true
+
+              def last_name
+                object.contact_data.last_name
+              end
+            end
+          end
+        RUBY
+      end
+
       context "when custom :resolver_method is configured for field" do
         it "registers offenses" do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
The root node detection would previously pick the module node resulting
in no class contents (and no method definitions) found. The easiest way
to support modules was to consider a class a root node if its parent is
a module.

This wouldn't support complex edge-cases where there's further nesting
going on, but this should handle the standard module nesting cases at
least.