### PR TITLE
 ExtractInputType: show all excess args in offense

### DIFF
--- a/lib/rubocop/cop/graphql/extract_input_type.rb
+++ b/lib/rubocop/cop/graphql/extract_input_type.rb
@@ -32,7 +32,12 @@ module RuboCop
           if (body = schema_member.body)
             arguments = body.select { |node| argument?(node) }
 
-            add_offense(arguments.last) if arguments.count > cop_config["MaxArguments"]
+            excess_arguments = arguments.count - cop_config["MaxArguments"]
+            return unless excess_arguments.positive?
+
+            arguments.last(excess_arguments).each do |excess_argument|
+              add_offense(excess_argument)
+            end
           end
         end
       end

--- a/spec/rubocop/cop/graphql/extract_input_type_spec.rb
+++ b/spec/rubocop/cop/graphql/extract_input_type_spec.rb
@@ -34,12 +34,13 @@ RSpec.describe RuboCop::Cop::GraphQL::ExtractInputType do
   end
 
   context "when count of fields is more than Max fields" do
-    it "registers an offense" do
+    it "registers an offense for each line over Max fields" do
       expect_offense(<<~RUBY)
         class UpdateUser < BaseMutation
           argument :uuid, ID, required: true
           argument :first_name, String, required: true
           argument :last_name, String, required: true
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider moving arguments to a new input type
           argument :email, String, required: true
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Consider moving arguments to a new input type
         end


### PR DESCRIPTION
I believe this makes it clearer what is wrong when introducing the cop to an existing code base, where a mutation may already have an excess of arguments.

Otherwise, you delete an argument, the errors moves up a line, and so on until you get below MaxArguments.

Just a draft for now with no spec improvements to confirm you're open to PRs! Happy to fix up anything that's broken, which may be everything haha.