### PR TITLE
Improve multiline description detection

### DIFF
--- a/lib/rubocop-graphql.rb
+++ b/lib/rubocop-graphql.rb
@@ -7,6 +7,7 @@ require_relative "rubocop/graphql/ext/snake_case"
 require_relative "rubocop/graphql"
 require_relative "rubocop/graphql/version"
 require_relative "rubocop/graphql/inject"
+require_relative "rubocop/graphql/description_method"
 require_relative "rubocop/graphql/node_pattern"
 
 require_relative "rubocop/graphql/argument"

--- a/lib/rubocop/cop/graphql/object_description.rb
+++ b/lib/rubocop/cop/graphql/object_description.rb
@@ -22,19 +22,12 @@ module RuboCop
       #
       class ObjectDescription < Cop
         include RuboCop::GraphQL::NodePattern
+        include RuboCop::GraphQL::DescriptionMethod
 
         MSG = "Missing type description"
 
         def_node_matcher :has_i18n_description?, <<~PATTERN
           (send nil? :description (send (const nil? :I18n) :t ...))
-        PATTERN
-
-        def_node_matcher :has_string_description?, <<~PATTERN
-          (send nil? :description (:str $_))
-        PATTERN
-
-        def_node_matcher :has_multiline_string_description?, <<~PATTERN
-          (send nil? :description (:dstr ...))
         PATTERN
 
         def_node_matcher :interface?, <<~PATTERN
@@ -59,8 +52,7 @@ module RuboCop
 
         def has_description?(node)
           has_i18n_description?(node) ||
-            has_string_description?(node) ||
-            has_multiline_string_description?(node)
+            description_kwarg?(node)
         end
 
         def child_nodes(node)

--- a/lib/rubocop/graphql/argument/block.rb
+++ b/lib/rubocop/graphql/argument/block.rb
@@ -5,6 +5,7 @@ module RuboCop
     class Argument
       class Block
         extend RuboCop::NodePattern::Macros
+        include DescriptionMethod
 
         def_node_matcher :argument_block, <<~PATTERN
           (block
@@ -14,16 +15,12 @@ module RuboCop
           )
         PATTERN
 
-        def_node_matcher :description_kwarg?, <<~PATTERN
-          (send nil? :description (str ...))
-        PATTERN
-
         def initialize(argument_node)
           @nodes = argument_block(argument_node) || []
         end
 
         def description
-          @nodes.find { |kwarg| description_kwarg?(kwarg) }
+          find_description_method(@nodes)
         end
       end
     end

--- a/lib/rubocop/graphql/description_method.rb
+++ b/lib/rubocop/graphql/description_method.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module GraphQL
+    # Matches a variety of description formats commonly seen in Rails applications
+    #
+    #   description 'blah'
+    #
+    #   description "blah"
+    #
+    #   description <<~EOT
+    #      blah
+    #      bloop
+    #   EOT
+    #
+    #   description <<-EOT.squish
+    #      blah
+    #      bloop
+    #   EOT
+    module DescriptionMethod
+      extend RuboCop::NodePattern::Macros
+
+      def_node_matcher :description_kwarg?, <<~PATTERN
+        (send nil? :description {({str|dstr} ...)|(send ({str|dstr} ...) _)})
+      PATTERN
+
+      def find_description_method(nodes)
+        nodes.find { |kwarg| description_kwarg?(kwarg) }
+      end
+    end
+  end
+end

--- a/lib/rubocop/graphql/field/block.rb
+++ b/lib/rubocop/graphql/field/block.rb
@@ -5,6 +5,7 @@ module RuboCop
     class Field
       class Block
         extend RuboCop::NodePattern::Macros
+        include DescriptionMethod
 
         def_node_matcher :field_block, <<~PATTERN
           (block
@@ -14,16 +15,12 @@ module RuboCop
           )
         PATTERN
 
-        def_node_matcher :description_kwarg?, <<~PATTERN
-          (send nil? :description (str ...))
-        PATTERN
-
         def initialize(field_node)
           @nodes = field_block(field_node) || []
         end
 
         def description
-          @nodes.find { |kwarg| description_kwarg?(kwarg) }
+          find_description_method(@nodes)
         end
       end
     end

--- a/spec/rubocop/cop/graphql/argument_description_spec.rb
+++ b/spec/rubocop/cop/graphql/argument_description_spec.rb
@@ -85,6 +85,58 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription do
       end
     end
 
+    context "when description is passed inside block as a single line heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do
+                description <<~EOT
+                  Size of avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is passed inside block as a multiline heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do
+                description <<~EOT
+                  Size
+                  of
+                  avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is passed inside block as a processed multiline heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do
+                description <<-EOT.strip
+                  Size
+                  of
+                  avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
     it "registers an offense" do
       expect_offense(<<~RUBY)
         class User < BaseType

--- a/spec/rubocop/cop/graphql/object_description_spec.rb
+++ b/spec/rubocop/cop/graphql/object_description_spec.rb
@@ -26,11 +26,24 @@ RSpec.describe RuboCop::Cop::GraphQL::ObjectDescription do
         end
       end
 
-      context "when description is heredoc" do
+      context "when description is multiline heredoc" do
         it "does not register an offense" do
           expect_no_offenses(<<~RUBY)
             class Types::UserType < Types::BaseObject
               description <<~MSG
+                Represents application
+                user
+              MSG
+            end
+          RUBY
+        end
+      end
+
+      context "when description is a processed heredoc" do
+        it "does not register an offense" do
+          expect_no_offenses(<<~RUBY)
+            class Types::UserType < Types::BaseObject
+              description <<-MSG.strip
                 Represents application user
               MSG
             end


### PR DESCRIPTION
As we have expanded our use of this gem we've found even after recent changes, heredoc description support is patchy. This PR attempts to DRY up the implementation for that, and improve it, with tests to boot.