### PR TITLE
Fix legacy description handling for argument types

### DIFF
--- a/lib/rubocop/graphql/argument/kwargs.rb
+++ b/lib/rubocop/graphql/argument/kwargs.rb
@@ -20,11 +20,11 @@ module RuboCop
         PATTERN
 
         def initialize(argument_node)
-          @nodes = argument_kwargs(argument_node)
+          @nodes = argument_kwargs(argument_node) || []
         end
 
         def description
-          @nodes&.find { |kwarg| description_kwarg?(kwarg) }
+          @nodes.find { |kwarg| description_kwarg?(kwarg) }
         end
       end
     end

--- a/lib/rubocop/graphql/argument/kwargs.rb
+++ b/lib/rubocop/graphql/argument/kwargs.rb
@@ -24,7 +24,7 @@ module RuboCop
         end
 
         def description
-          @nodes.find { |kwarg| description_kwarg?(kwarg) }
+          @nodes&.find { |kwarg| description_kwarg?(kwarg) }
         end
       end
     end

--- a/lib/rubocop/graphql/description_method.rb
+++ b/lib/rubocop/graphql/description_method.rb
@@ -25,7 +25,7 @@ module RuboCop
       PATTERN
 
       def find_description_method(nodes)
-        nodes&.find { |kwarg| description_kwarg?(kwarg) }
+        nodes.find { |kwarg| description_kwarg?(kwarg) }
       end
     end
   end

--- a/lib/rubocop/graphql/description_method.rb
+++ b/lib/rubocop/graphql/description_method.rb
@@ -25,7 +25,7 @@ module RuboCop
       PATTERN
 
       def find_description_method(nodes)
-        nodes.find { |kwarg| description_kwarg?(kwarg) }
+        nodes&.find { |kwarg| description_kwarg?(kwarg) }
       end
     end
   end

--- a/spec/rubocop/cop/graphql/argument_description_spec.rb
+++ b/spec/rubocop/cop/graphql/argument_description_spec.rb
@@ -148,4 +148,15 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription do
       RUBY
     end
   end
+
+  context "when description is not passed in for legacy DSL define style" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        UserType = GraphQL::InputObjectType.define do
+          argument :id, ID
+          ^^^^^^^^^^^^^^^^ Missing argument description
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
### Context

When handling legacy DSL behavior for GraphQL (1.8x and below) argument types, it looks like the `description` parameter into the class method doesn't work for the rubocop. Potentially other versions too outside of legacy, maybe the assumption is that we actually always wrote code expecting kwargs. That said, I added a `||` operator since it looks like the node it's finding is null to collapse to `[]`. Happy to take a better approach here if you think there is one. I also added a spec so that we can replicate behavior.


### Changelog
* Add safe navigation to `[]`
* Add spec to cover legacy define DSL behavior