### PR TITLE
Autocorrect field names

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -48,6 +48,7 @@ GraphQL/FieldName:
   Enabled: true
   VersionAdded: '0.80'
   Description: 'This cop checks whether field names are snake_case'
+  SafeAutoCorrect: false
 
 GraphQL/ExtractInputType:
   Enabled: true

--- a/lib/refinements/underscore_string.rb
+++ b/lib/refinements/underscore_string.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module UnderscoreString
+  refine String do
+    # This method was extracted from activesupport in Rails:
+    # https://github.com/rails/rails/blob/8dab534ca81dd32c6a83ac03596a1feb7ddaaca7/activesupport/lib/active_support/inflector/methods.rb#L96
+
+    def underscore
+      camel_cased_word = self
+      regex = /(?:(?<=([A-Za-z\d]))|\b)((?=a)b)(?=\b|[^a-z])/
+      return camel_cased_word.to_s unless /[A-Z-]|::/.match?(camel_cased_word)
+
+      word = camel_cased_word.to_s.gsub("::", "/")
+      word.gsub!(regex) { "#{Regexp.last_match(1) && '_'}#{Regexp.last_match(2).downcase}" }
+      word.gsub!(/([A-Z\d]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
+        (Regexp.last_match(1) || Regexp.last_match(2)) << "_"
+      end
+      word.tr!("-", "_")
+      word.downcase!
+      word
+    end
+  end
+end

--- a/lib/rubocop/cop/graphql/field_name.rb
+++ b/lib/rubocop/cop/graphql/field_name.rb
@@ -19,6 +19,7 @@ module RuboCop
       #   end
       #
       class FieldName < Base
+        extend AutoCorrector
         include RuboCop::GraphQL::NodePattern
 
         using RuboCop::GraphQL::Ext::SnakeCase
@@ -31,7 +32,34 @@ module RuboCop
           field = RuboCop::GraphQL::Field.new(node)
           return if field.name.snake_case?
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            rename_field_name(corrector, field, node)
+          end
+        end
+
+        private
+
+        def rename_field_name(corrector, field, node)
+          name_field = field.name.to_s
+          new_line = node.source.sub(name_field, underscore(name_field))
+          corrector.replace(node, new_line)
+        end
+
+        # This method was extracted from activesupport in Rails:
+        # https://github.com/rails/rails/blob/8dab534ca81dd32c6a83ac03596a1feb7ddaaca7/activesupport/lib/active_support/inflector/methods.rb#L96
+
+        def underscore(camel_cased_word)
+          regex = /(?:(?<=([A-Za-z\d]))|\b)((?=a)b)(?=\b|[^a-z])/
+          return camel_cased_word.to_s unless /[A-Z-]|::/.match?(camel_cased_word)
+
+          word = camel_cased_word.to_s.gsub("::", "/")
+          word.gsub!(regex) { "#{Regexp.last_match(1) && '_'}#{Regexp.last_match(2).downcase}" }
+          word.gsub!(/([A-Z\d]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
+            (Regexp.last_match(1) || Regexp.last_match(2)) << "_"
+          end
+          word.tr!("-", "_")
+          word.downcase!
+          word
         end
       end
     end

--- a/lib/rubocop/cop/graphql/field_name.rb
+++ b/lib/rubocop/cop/graphql/field_name.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative "../../../refinements/underscore_string"
+
+using UnderscoreString unless String.method_defined?(:underscore)
+
 module RuboCop
   module Cop
     module GraphQL
@@ -41,25 +45,8 @@ module RuboCop
 
         def rename_field_name(corrector, field, node)
           name_field = field.name.to_s
-          new_line = node.source.sub(name_field, underscore(name_field))
+          new_line = node.source.sub(name_field, name_field.underscore)
           corrector.replace(node, new_line)
-        end
-
-        # This method was extracted from activesupport in Rails:
-        # https://github.com/rails/rails/blob/8dab534ca81dd32c6a83ac03596a1feb7ddaaca7/activesupport/lib/active_support/inflector/methods.rb#L96
-
-        def underscore(camel_cased_word)
-          regex = /(?:(?<=([A-Za-z\d]))|\b)((?=a)b)(?=\b|[^a-z])/
-          return camel_cased_word.to_s unless /[A-Z-]|::/.match?(camel_cased_word)
-
-          word = camel_cased_word.to_s.gsub("::", "/")
-          word.gsub!(regex) { "#{Regexp.last_match(1) && '_'}#{Regexp.last_match(2).downcase}" }
-          word.gsub!(/([A-Z\d]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
-            (Regexp.last_match(1) || Regexp.last_match(2)) << "_"
-          end
-          word.tr!("-", "_")
-          word.downcase!
-          word
         end
       end
     end

--- a/spec/rubocop/cop/graphql/field_name_spec.rb
+++ b/spec/rubocop/cop/graphql/field_name_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldName do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use snake_case for field names
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        class UserType < BaseType
+          field :first_name, String, null: true
+        end
+      RUBY
     end
   end
 end


### PR DESCRIPTION
This adds an autocorrect option for the FieldName cop. The `underscore` method was directly taken from the Rails activesupport codebase, I guessed that was a better idea than requiring it as a dependency.

Because moving to underscore can sometimes produce unexpected results I marked it as a not safe auto correct. It seems like we'd want to make sure people are aware and paying attention to their field names. I could be talked into removing that, I don't have a strong opinion.

I'm happy to make any other adjustments if it's helpful.