### PR TITLE
[Graphql/FieldHashKey] cop - only match symbol or string keys

### DIFF
--- a/lib/rubocop/cop/graphql/field_hash_key.rb
+++ b/lib/rubocop/cop/graphql/field_hash_key.rb
@@ -34,7 +34,7 @@ module RuboCop
             (args)
             (send
               (send nil? :object) :[]
-              (_type $_)
+              ({sym str} $_)
             )
           )
         PATTERN

--- a/spec/rubocop/cop/graphql/field_hash_key_spec.rb
+++ b/spec/rubocop/cop/graphql/field_hash_key_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldHashKey do
       end
     end
 
+    context "when hash key is an integer" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :phone, String, null: true
+
+            def phone
+              object[0]
+            end
+          end
+        RUBY
+      end
+    end
+
     context "when there are valid fields around" do
       it "registers an offense" do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixes issue #43.

I went conservative and had it only match symbol and string keys to keep things simple.