### PR TITLE
Adjust changelog_uri

### DIFF
--- a/rubocop-graphql.gemspec
+++ b/rubocop-graphql.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Adjust the URI so that link to the changelog is correct on RubyGems:

![Screen Shot 2021-12-23 at 04 20 16](https://user-images.githubusercontent.com/649935/147218568-0d1ec610-2e59-4403-9066-f929400b7d88.png)
.