### PR TITLE
Fix GraphQL/UnusedArgument cop to respect loads and as keyword

### DIFF
--- a/lib/rubocop/graphql/argument.rb
+++ b/lib/rubocop/graphql/argument.rb
@@ -13,6 +13,10 @@ module RuboCop
         (send nil? :argument (:sym $_) ...)
       PATTERN
 
+      def_node_matcher :argument_as, <<~PATTERN
+        (pair (sym :as) (sym $_))
+      PATTERN
+
       attr_reader :node
 
       def initialize(node)
@@ -21,6 +25,10 @@ module RuboCop
 
       def name
         @name ||= argument_name(@node)
+      end
+
+      def as
+        @as ||= argument_as(kwargs.as)
       end
 
       def description

--- a/lib/rubocop/graphql/argument/kwargs.rb
+++ b/lib/rubocop/graphql/argument/kwargs.rb
@@ -23,6 +23,10 @@ module RuboCop
           (pair (sym :loads) ...)
         PATTERN
 
+        def_node_matcher :as_kwarg?, <<~PATTERN
+          (pair (sym :as) ...)
+        PATTERN
+
         def initialize(argument_node)
           @nodes = argument_kwargs(argument_node) || []
         end
@@ -33,6 +37,10 @@ module RuboCop
 
         def loads
           @nodes.find { |kwarg| loads_kwarg?(kwarg) }
+        end
+
+        def as
+          @nodes.find { |kwarg| as_kwarg?(kwarg) }
         end
       end
     end

--- a/lib/rubocop/graphql/argument/kwargs.rb
+++ b/lib/rubocop/graphql/argument/kwargs.rb
@@ -19,12 +19,20 @@ module RuboCop
           (pair (sym :description) ...)
         PATTERN
 
+        def_node_matcher :loads_kwarg?, <<~PATTERN
+          (pair (sym :loads) ...)
+        PATTERN
+
         def initialize(argument_node)
           @nodes = argument_kwargs(argument_node) || []
         end
 
         def description
           @nodes.find { |kwarg| description_kwarg?(kwarg) }
+        end
+
+        def loads
+          @nodes.find { |kwarg| loads_kwarg?(kwarg) }
         end
       end
     end

--- a/spec/rubocop/cop/graphql/unused_argument_spec.rb
+++ b/spec/rubocop/cop/graphql/unused_argument_spec.rb
@@ -37,8 +37,10 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
         class SomeResolver < Resolvers::Base
           argument :post_id, String, loads: Types::PostType
           argument :comment_ids, String, loads: Types::CommentType
+          argument :user_id, String, loads: Types::UserType, as: :owner
+          argument :notes_ids, String, loads: Types::NoteType, as: :remarks
 
-          def resolve(post:, comments:); end
+          def resolve(post:, comments:, owner:, remarks:); end
         end
       RUBY
     end
@@ -126,9 +128,11 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
           argument :arg2, String, required: true
           argument :user_id, String, loads: Types::UserType
           argument :card_ids, String, loads: Types::CardType
+          argument :post_id, String, loads: Types::PostType, as: :article
+          argument :comment_ids, String, loads: Types::CommentType, as: :notes
 
           def resolve; end
-          ^^^^^^^^^^^^^^^^ Arguments `arg1:, arg2:, user:, cards:` should be listed in the resolve signature.
+          ^^^^^^^^^^^^^^^^ Arguments `arg1:, arg2:, user:, cards:, article:, notes:` should be listed in the resolve signature.
         end
       RUBY
 
@@ -138,8 +142,10 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
           argument :arg2, String, required: true
           argument :user_id, String, loads: Types::UserType
           argument :card_ids, String, loads: Types::CardType
+          argument :post_id, String, loads: Types::PostType, as: :article
+          argument :comment_ids, String, loads: Types::CommentType, as: :notes
 
-          def resolve(arg1:, arg2:, user:, cards:); end
+          def resolve(arg1:, arg2:, user:, cards:, article:, notes:); end
         end
       RUBY
     end

--- a/spec/rubocop/cop/graphql/unused_argument_spec.rb
+++ b/spec/rubocop/cop/graphql/unused_argument_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
     end
   end
 
+  context "when args with loads are used" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class SomeResolver < Resolvers::Base
+          argument :post_id, String, loads: Types::PostType
+          argument :comment_ids, String, loads: Types::CommentType
+
+          def resolve(post:, comments:); end
+        end
+      RUBY
+    end
+  end
+
   context "when hash arg is used" do
     it "not registers an offense" do
       expect_no_offenses(<<~RUBY)
@@ -111,9 +124,11 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
         class SomeResolver < Resolvers::Base
           argument :arg1, String, required: true
           argument :arg2, String, required: true
+          argument :user_id, String, loads: Types::UserType
+          argument :card_ids, String, loads: Types::CardType
 
           def resolve; end
-          ^^^^^^^^^^^^^^^^ Arguments `arg1:, arg2:` should be listed in the resolve signature.
+          ^^^^^^^^^^^^^^^^ Arguments `arg1:, arg2:, user:, cards:` should be listed in the resolve signature.
         end
       RUBY
 
@@ -121,8 +136,10 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
         class SomeResolver < Resolvers::Base
           argument :arg1, String, required: true
           argument :arg2, String, required: true
+          argument :user_id, String, loads: Types::UserType
+          argument :card_ids, String, loads: Types::CardType
 
-          def resolve(arg1:, arg2:); end
+          def resolve(arg1:, arg2:, user:, cards:); end
         end
       RUBY
     end


### PR DESCRIPTION
Fix [missing](https://github.com/DmitryTsepelev/rubocop-graphql/pull/61#issuecomment-1004033377) `loads` and `as` keywords handle in argument definition.

Fixes #64 

/cc @jgrau