### PR TITLE
[UnusedArgument] Consider optional kwarg argument as declared

### DIFF
--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -84,12 +84,15 @@ module RuboCop
         end
 
         def find_unresolved_args(method_node, declared_arg_nodes)
-          resolve_method_kwargs = method_node.arguments.select(&:kwarg_type?).map do |node|
+          resolve_method_kwargs = method_node.arguments.select do |arg|
+            arg.kwarg_type? || arg.kwoptarg_type?
+          end
+          resolve_method_kwargs_names = resolve_method_kwargs.map do |node|
             node.node_parts[0]
           end.to_set
           declared_args = declared_arg_nodes.map { |node| RuboCop::GraphQL::Argument.new(node) }
-          declared_args.map(&:name).uniq.reject do |declared_arg|
-            resolve_method_kwargs.include?(declared_arg)
+          declared_args.map(&:name).uniq.reject do |declared_arg_name|
+            resolve_method_kwargs_names.include?(declared_arg_name)
           end
         end
 

--- a/spec/rubocop/cop/graphql/unused_argument_spec.rb
+++ b/spec/rubocop/cop/graphql/unused_argument_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
       expect_no_offenses(<<~RUBY)
         class SomeResolver < Resolvers::Base
           argument :arg1, String, required: true
-          argument :arg2, String, required: true
+          argument :arg2, String, required: false
 
-          def resolve(arg1:, arg2:); end
+          def resolve(arg1:, arg2: "hey"); end
         end
       RUBY
     end


### PR DESCRIPTION
Closes https://github.com/DmitryTsepelev/rubocop-graphql/issues/62

Current implementation doesn't recognize optional kwarg argument declarations because it filters by `kwarg_type`
But optional arg declaration is a valid declaration for our case so we should include those in the list before checking for inclusion

The chance is essentially
```diff
resolve_method_kwargs = method_node.arguments.select do |arg|
-  arg.kwarg_type?
+  arg.kwarg_type? || arg.kwoptarg_type?
end
```

but looks a bit bigger in the PR because of some refactoring i've introduced 

 