### PR TITLE
[UnusedArgument] Respect :as keyword even without :loads

### DIFF
--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -139,11 +139,10 @@ module RuboCop
         end
 
         def arg_name(declared_arg)
-          if declared_arg.kwargs.loads.nil?
-            declared_arg.name
-          else
-            declared_arg.as || inferred_arg_name(declared_arg.name.to_s)
-          end
+          return declared_arg.as if declared_arg.kwargs.as
+          return inferred_arg_name(declared_arg.name.to_s) if declared_arg.kwargs.loads
+
+          declared_arg.name
         end
 
         def_node_search :argument_declarations, <<~PATTERN

--- a/spec/rubocop/cop/graphql/unused_argument_spec.rb
+++ b/spec/rubocop/cop/graphql/unused_argument_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
           argument :comment_ids, String, loads: Types::CommentType
           argument :user_id, String, loads: Types::UserType, as: :owner
           argument :notes_ids, String, loads: Types::NoteType, as: :remarks
+          argument :data, String, required: false, as: :metadata
 
-          def resolve(post:, comments:, owner:, remarks:); end
+          def resolve(post:, comments:, owner:, remarks:, metadata:); end
         end
       RUBY
     end


### PR DESCRIPTION
One more tiny fix
`:as` keyword can be used without `:loads` so we need to always respect it if present
Conceptually the change is as tiny as:

```diff
-         if declared_arg.kwargs.loads.nil?
+         if declared_arg.kwargs.loads.nil? && declared_arg.kwargs.as.nil?
            declared_arg.name
          else
            declared_arg.as || inferred_arg_name(declared_arg.name.to_s)
          end
```
but I did a bit of refactoring :) 