### PR TITLE
[Cleanup] Remove unused NodeUniqueness#nested_class? method

### DIFF
--- a/lib/rubocop/graphql/node_uniqueness.rb
+++ b/lib/rubocop/graphql/node_uniqueness.rb
@@ -7,10 +7,6 @@ module RuboCop
       def current_class_full_name(node)
         node.each_ancestor(:class).map(&:defined_module_name).join("::")
       end
-
-      def nested_class?(node)
-        node.each_ancestor(:class).any?
-      end
     end
   end
 end


### PR DESCRIPTION
Sorry I think I might have wrongly rebased some of my previous PRs so we left with an unused method 
Currently this method lives in it's own class:
https://github.com/DmitryTsepelev/rubocop-graphql/blob/c551b16a88cf09963d3d7679c31d2ba3b9475984/lib/rubocop/graphql/class.rb#L12-L14
so we don't need the one in the `NodeUniqueness`

I believe since this is just a cleanup it shouldn't require a version bump but totally up to you. 
