### PR TITLE
[UnusedArgument] Ignore arguments defined in a nested class

### DIFF
--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -72,7 +72,7 @@ module RuboCop
                       arg.arg_type? || arg.kwrestarg_type?
                     end
 
-          declared_arg_nodes = argument_declarations(node)
+          declared_arg_nodes = find_declared_arg_nodes(node)
           return unless declared_arg_nodes.any?
 
           unresolved_args = find_unresolved_args(resolve_method_node, declared_arg_nodes)
@@ -80,6 +80,13 @@ module RuboCop
         end
 
         private
+
+        def find_declared_arg_nodes(node)
+          argument_declarations(node).select do |arg_declaration|
+            # argument is declared on the same class that is being analyzed
+            arg_declaration.each_ancestor(:class).first == node
+          end
+        end
 
         def find_resolve_method_node(node)
           resolve_method_nodes = resolve_method_definition(node)

--- a/spec/rubocop/cop/graphql/unused_argument_spec.rb
+++ b/spec/rubocop/cop/graphql/unused_argument_spec.rb
@@ -9,10 +9,15 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
     it "not registers an offense" do
       expect_no_offenses(<<~RUBY)
         class SomeResolver < Resolvers::Base
+          class Input < GraphQL::Schema::InputObject
+            argument :arg4, String, required: true
+          end
+
           argument :arg1, String, required: true
           argument :arg2, String, required: false
+          argunent :arg3, Input, required: true
 
-          def resolve(arg1:, arg2: "hey"); end
+          def resolve(arg1:, arg2: "hey", arg3:); end
         end
       RUBY
     end


### PR DESCRIPTION
This is a very similar issue to argument & field uniqueness 
Since we are looking for any `argument :arg` definitions in the top-level class we get every definition even if it's declared in a nested class
To prevent this I'm adding filtering to make sure that we only analyze arguments defined on the same class that is being parsed by comparing it with the `node` argument  

`on_class` method was violating method complexity cop so I had to define a new method