### PR TITLE
[UnusedArgument] Do not look for `resolve` method in nested classes

### DIFF
--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -90,7 +90,10 @@ module RuboCop
 
         def find_resolve_method_node(node)
           resolve_method_nodes = resolve_method_definition(node)
-          resolve_method_nodes.to_a.last if resolve_method_nodes.any?
+          resolve_method_nodes.find do |resolve_node|
+            # reject resolve methods from other classes
+            resolve_node.each_ancestor(:class).first == node
+          end
         end
 
         def find_unresolved_args(method_node, declared_arg_nodes)

--- a/spec/rubocop/cop/graphql/unused_argument_spec.rb
+++ b/spec/rubocop/cop/graphql/unused_argument_spec.rb
@@ -156,4 +156,21 @@ RSpec.describe RuboCop::Cop::GraphQL::UnusedArgument do
       RUBY
     end
   end
+
+  context "when resolve method belongs to a different class" do
+    it "does not register an offence" do
+      expect_no_offenses(<<~RUBY)
+        class MyMutation < GraphApi::Mutation
+          class MyHelper
+            def resolve
+            end
+          end
+
+          argument :arg1, String, required: true
+
+          self.resolve = -> {}
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fix for a corner case when the cop was looking for any `resolve` method in the class and trying to find offenses for a wrong method in case if there is no `resolve` method defined on the class itself

Example is a little abstract but we have a real case in our app so I can assume some variations of this code can exist so it's better to account for them