### PR TITLE
Update Ordered Arguments Auto Correction to Respect Blocks

### DIFF
--- a/lib/rubocop/cop/graphql/ordered_arguments.rb
+++ b/lib/rubocop/cop/graphql/ordered_arguments.rb
@@ -97,7 +97,7 @@ module RuboCop
         end
 
         def argument_name(node)
-          argument = node.block_type? ? node.children.first.first_argument : node.first_argument.value.to_s
+          argument = node.block_type? ? node.children.first.first_argument : node.first_argument
 
           argument.value.to_s
         end

--- a/lib/rubocop/cop/graphql/ordered_arguments.rb
+++ b/lib/rubocop/cop/graphql/ordered_arguments.rb
@@ -57,22 +57,15 @@ module RuboCop
               "Field `%<current>s` should appear before `%<previous>s`."
 
         def on_class(node)
-          argument_declarations = []
-
           declarations_with_blocks = argument_declarations_with_blocks(node)
           declarations_without_blocks = argument_declarations_without_blocks(node)
 
-          declarations_without_blocks.each do |node|
+          argument_declarations = declarations_without_blocks.map do |node|
             arg_name = argument_name(node)
             same_arg_with_block_declaration = declarations_with_blocks.find { |dec| argument_name(dec) == arg_name }
 
-            if same_arg_with_block_declaration
-              argument_declarations << same_arg_with_block_declaration
-            else
-              argument_declarations << node
-            end
+            same_arg_with_block_declaration || node
           end
-
 
           argument_declarations.each_cons(2) do |previous, current|
             next unless consecutive_lines(previous, current)

--- a/lib/rubocop/cop/graphql/ordered_arguments.rb
+++ b/lib/rubocop/cop/graphql/ordered_arguments.rb
@@ -62,7 +62,9 @@ module RuboCop
 
           argument_declarations = declarations_without_blocks.map do |node|
             arg_name = argument_name(node)
-            same_arg_with_block_declaration = declarations_with_blocks.find { |dec| argument_name(dec) == arg_name }
+            same_arg_with_block_declaration = declarations_with_blocks.find do |dec|
+              argument_name(dec) == arg_name
+            end
 
             same_arg_with_block_declaration || node
           end

--- a/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
@@ -160,4 +160,31 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedArguments do
       RUBY
     end
   end
+
+  context "when multiple unordered argument declarations contain blocks" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class UpdateProfile < BaseMutation
+          argument :uuid, ID, required: true do
+            description 'oranges'
+          end
+          argument :email, String, required: false do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Arguments should be sorted in an alphabetical order within their section. Field `email` should appear before `uuid`.
+            description 'the user email'
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class UpdateProfile < BaseMutation
+          argument :email, String, required: false do
+            description 'the user email'
+          end
+          argument :uuid, ID, required: true do
+            description 'oranges'
+          end
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
@@ -166,10 +166,10 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedArguments do
       expect_offense(<<~RUBY)
         class UpdateProfile < BaseMutation
           argument :uuid, ID, required: true do
-            description 'oranges'
+            description 'the profile UUID'
           end
           argument :email, String, required: false do
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Arguments should be sorted in an alphabetical order within their section. Field `email` should appear before `uuid`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Arguments should be sorted in an alphabetical order within their section. Field `email` should appear before `uuid`.
             description 'the user email'
           end
         end
@@ -181,7 +181,7 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedArguments do
             description 'the user email'
           end
           argument :uuid, ID, required: true do
-            description 'oranges'
+            description 'the profile UUID'
           end
         end
       RUBY

--- a/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
@@ -137,4 +137,27 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedArguments do
       RUBY
     end
   end
+
+  context "when an unordered argument declaration contains a block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class UpdateProfile < BaseMutation
+          argument :uuid, ID, required: true
+          argument :email, String, required: false do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Arguments should be sorted in an alphabetical order within their section. Field `email` should appear before `uuid`.
+            description 'the user email'
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class UpdateProfile < BaseMutation
+          argument :email, String, required: false do
+            description 'the user email'
+          end
+          argument :uuid, ID, required: true
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Address #74 

## What changed
Search for argument declarations that contain blocks so the auto corrector will swap the argument declaration in its entirety. I took a stab at this and man, it took me a bit to understand how to write the pattern for the `def_node_search` and still, I think "understand" is a generous term for what I did.

Anyway, I'm very much open to critiques or edits here.

Thanks for you hard work!

|me & `def_node_search`|
|-|
|![](https://media3.giphy.com/media/4ZswIRaLo7i5q/200.gif?cid=5a38a5a22af5wwd9hxtoxvkcsn825lsxes01lgdeh1sov4o6&rid=200.gif)| 