### PR TITLE
[FieldMethod, FieldHashKey] Don't raise offense when method/hash key name conflicts with keyword

### DIFF
--- a/lib/rubocop/cop/graphql/field_hash_key.rb
+++ b/lib/rubocop/cop/graphql/field_hash_key.rb
@@ -47,10 +47,13 @@ module RuboCop
           field = RuboCop::GraphQL::Field.new(node)
           method_definition = resolver_method_definition_for(field)
 
-          if (suggested_hash_key_name = hash_key_to_use(method_definition))
-            add_offense(node, message: message(suggested_hash_key_name)) do |corrector|
-              autocorrect(corrector, node)
-            end
+          suggested_hash_key_name = hash_key_to_use(method_definition)
+
+          return if suggested_hash_key_name.nil?
+          return if RuboCop::GraphQL::Field::CONFLICT_FIELD_NAMES.include?(suggested_hash_key_name)
+
+          add_offense(node, message: message(suggested_hash_key_name)) do |corrector|
+            autocorrect(corrector, node)
           end
         end
 

--- a/lib/rubocop/cop/graphql/field_method.rb
+++ b/lib/rubocop/cop/graphql/field_method.rb
@@ -46,10 +46,13 @@ module RuboCop
           field = RuboCop::GraphQL::Field.new(node)
           method_definition = suggest_method_name_for(field)
 
-          if (suggested_method_name = method_to_use(method_definition))
-            add_offense(node, message: message(suggested_method_name)) do |corrector|
-              autocorrect(corrector, node)
-            end
+          suggested_method_name = method_to_use(method_definition)
+
+          return if suggested_method_name.nil?
+          return if RuboCop::GraphQL::Field::CONFLICT_FIELD_NAMES.include?(suggested_method_name)
+
+          add_offense(node, message: message(suggested_method_name)) do |corrector|
+            autocorrect(corrector, node)
           end
         end
 

--- a/lib/rubocop/graphql/field.rb
+++ b/lib/rubocop/graphql/field.rb
@@ -6,6 +6,18 @@ module RuboCop
       extend Forwardable
       extend RuboCop::NodePattern::Macros
 
+      # These constants were extracted from graphql-ruby in lib/graphql/schema/member/has_fields.rb
+      RUBY_KEYWORDS = %i[class module def undef begin rescue ensure end if unless then elsif else
+                         case when while until for break next redo retry in do return yield super
+                         self nil true false and or not alias defined? BEGIN END __LINE__
+                         __FILE__].freeze
+
+      GRAPHQL_RUBY_KEYWORDS = %i[context object raw_value].freeze
+
+      CONFLICT_FIELD_NAMES = Set.new(
+        GRAPHQL_RUBY_KEYWORDS + RUBY_KEYWORDS + Object.instance_methods
+      )
+
       def_delegators :@node, :sibling_index, :parent
 
       def_node_matcher :field_name, <<~PATTERN

--- a/spec/rubocop/cop/graphql/field_hash_key_spec.rb
+++ b/spec/rubocop/cop/graphql/field_hash_key_spec.rb
@@ -103,6 +103,20 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldHashKey do
         RUBY
       end
     end
+
+    context "when suggested hash_key name would conflict with Ruby or GraphQL-Ruby keywords" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :context, String, null: true, resolver_method: :user_context
+
+            def user_context
+              object[:context]
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context "when resolver method is more complex" do

--- a/spec/rubocop/cop/graphql/field_method_spec.rb
+++ b/spec/rubocop/cop/graphql/field_method_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldMethod do
         RUBY
       end
     end
+
+    context "when suggested method name would conflict with Ruby or GraphQL-Ruby keywords" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :context, String, null: true, resolver_method: :user_context
+
+            def user_context
+              object.context
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context "when resolver method is more complex" do


### PR DESCRIPTION
Don't raise an offense for `FieldMethod` and `FieldHashKey` when the resolver method resolves using a method or hash key whose name conflicts with a Ruby or GraphQL-Ruby keyword.

For example,
```ruby
field :context, String, null: true, resolver_method: :user_context
def user_context
  object.context
end
```
would originally correct to:
```ruby
field :context, String, null: true, resolver_method: :user_context, method: :context
```
which would incorrectly resolve using the `context` instance method instead of returning `object.context`.

### Solution
The list of keywords is taken from https://github.com/rmosolgo/graphql-ruby/blob/a08c86f097395e27272fdead5037d7b3ef03401e/lib/graphql/schema/member/has_fields.rb#L53-L67

Both cops will now simply skip every time the suggested method / hash key name would conflict with a keyword.