### PR TITLE
[FieldDescription, ArgumentDescription] Support descriptions in blocks with an argument

### DIFF
--- a/lib/rubocop/cop/graphql/object_description.rb
+++ b/lib/rubocop/cop/graphql/object_description.rb
@@ -52,7 +52,7 @@ module RuboCop
 
         def has_description?(node)
           has_i18n_description?(node) ||
-            description_kwarg?(node)
+            description_method_call?(node)
         end
 
         def child_nodes(node)

--- a/lib/rubocop/graphql/argument/block.rb
+++ b/lib/rubocop/graphql/argument/block.rb
@@ -10,7 +10,7 @@ module RuboCop
         def_node_matcher :argument_block, <<~PATTERN
           (block
             (send nil? :argument ...)
-            (args)
+            (args ...)
             $...
           )
         PATTERN

--- a/lib/rubocop/graphql/description_method.rb
+++ b/lib/rubocop/graphql/description_method.rb
@@ -20,13 +20,18 @@ module RuboCop
     module DescriptionMethod
       extend RuboCop::NodePattern::Macros
 
-      def_node_matcher :description_kwarg?, <<~PATTERN
-        (send nil? :description
-          {({str|dstr|const} ...)|(send const ...)|(send ({str|dstr} ...) _)})
+      DESCRIPTION_STRING = "{({str|dstr|const} ...)|(send const ...)|(send ({str|dstr} ...) _)}"
+
+      def_node_matcher :description_method_call?, <<~PATTERN
+        (send nil? :description #{DESCRIPTION_STRING})
+      PATTERN
+
+      def_node_matcher :description_with_block_arg?, <<~PATTERN
+        (send (lvar _) {:description= :description} #{DESCRIPTION_STRING})
       PATTERN
 
       def find_description_method(nodes)
-        nodes.find { |kwarg| description_kwarg?(kwarg) }
+        nodes.find { |kwarg| description_method_call?(kwarg) || description_with_block_arg?(kwarg) }
       end
     end
   end

--- a/lib/rubocop/graphql/field/block.rb
+++ b/lib/rubocop/graphql/field/block.rb
@@ -10,7 +10,7 @@ module RuboCop
         def_node_matcher :field_block, <<~PATTERN
           (block
             (send nil? :field ...)
-            (args)
+            (args ...)
             {(begin $...)|$...}
           )
         PATTERN

--- a/spec/rubocop/cop/graphql/argument_description_spec.rb
+++ b/spec/rubocop/cop/graphql/argument_description_spec.rb
@@ -35,6 +35,30 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription do
         end
       RUBY
     end
+
+    context "when description is set with block argument" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class BanUser < BaseMutation
+            argument :uuid, ID, required: true do |argument|
+              argument.description = "UUID of the user to ban"
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is passed with block argument" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class BanUser < BaseMutation
+            argument :uuid, ID, required: true do |argument|
+              argument.description "UUID of the user to ban"
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   it "registers an offense" do
@@ -85,6 +109,34 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription do
       end
     end
 
+    context "when description is set inside block with argument" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description = "Size of avatar"
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is passed inside block with argument" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description "Size of avatar"
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
     context "when description is passed inside block as a single line heredoc" do
       it "not registers an offense" do
         expect_no_offenses(<<~RUBY)
@@ -92,6 +144,38 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription do
             field :avatar_url, String do
               argument :size, Integer, required: true do
                 description <<~EOT
+                  Size of avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is set inside block with argument as a single line heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description = <<~EOT
+                  Size of avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is passed inside block with argument as a single line heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description <<~EOT
                   Size of avatar
                 EOT
               end
@@ -119,6 +203,42 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription do
       end
     end
 
+    context "when description is set inside block with argument as a multiline heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description = <<~EOT
+                  Size
+                  of
+                  avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is passed inside block with argument as a multiline heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description <<~EOT
+                  Size
+                  of
+                  avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
     context "when description is passed inside block as a processed multiline heredoc" do
       it "not registers an offense" do
         expect_no_offenses(<<~RUBY)
@@ -126,6 +246,42 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription do
             field :avatar_url, String do
               argument :size, Integer, required: true do
                 description <<-EOT.strip
+                  Size
+                  of
+                  avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is set inside block with argument as a processed multiline heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description = <<-EOT.strip
+                  Size
+                  of
+                  avatar
+                EOT
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when description is passed inside block with arg as a processed multiline heredoc" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class User < BaseType
+            field :avatar_url, String do
+              argument :size, Integer, required: true do |argument|
+                argument.description <<-EOT.strip
                   Size
                   of
                   avatar

--- a/spec/rubocop/cop/graphql/field_description_spec.rb
+++ b/spec/rubocop/cop/graphql/field_description_spec.rb
@@ -51,6 +51,58 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldDescription do
     end
   end
 
+  context "when description is set inside block with argument" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class UserType < BaseType
+          field :first_name, String, null: true do |field|
+            field.description = "First name"
+          end
+        end
+      RUBY
+    end
+
+    context "when block also contains something else" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :first_name, String, null: true do |field|
+              field.description = "First name"
+
+              field.argument :capitalized, String, required: false
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context "when description is passed inside block with argument" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class UserType < BaseType
+          field :first_name, String, null: true do |field|
+            field.description "First name"
+          end
+        end
+      RUBY
+    end
+
+    context "when block also contains something else" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :first_name, String, null: true do |field|
+              field.description "First name"
+
+              field.argument :capitalized, String, required: false
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
   it "registers an offense" do
     expect_offense(<<~RUBY)
       class UserType < BaseType


### PR DESCRIPTION
Update `FieldDescription` and `ArgumentDescription` so that they support fields/arguments defined with blocks *with an argument*:
```ruby
# Description assignment
field :name, String, null: true do |field|
  field.description = "Name of user."
end

# Description method
field :name, String, null: true do |field|
  field.description "Name of user."
end
```