### PR TITLE
Fix auto-correction when there are multiple offenses detected (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#86](https://github.com/DmitryTsepelev/rubocop-graphql/pull/86) [OrderedFields] [OrderedArguments]: Fix false positive when fields use arguments ([@Darhazer][])
+
 ## 0.14.3 (2022-05-16)
 
 - [PR#82](https://github.com/DmitryTsepelev/rubocop-graphql/pull/82) [ArgumentUniqueness]: properly handle ivars in the field name ([@DmitryTsepelev][])
@@ -177,3 +179,4 @@
 [@roger-kang-mo]: https://github.com/roger-kang-mo
 [@alex4787]: https://github.com/alex4787
 [@nipe0324]: https://github.com/nipe0324
+[@Darhazer]: https://github.com/Darhazer

--- a/lib/rubocop/graphql/swap_range.rb
+++ b/lib/rubocop/graphql/swap_range.rb
@@ -3,22 +3,22 @@
 module RuboCop
   module GraphQL
     module SwapRange
+      include RuboCop::Cop::RangeHelp
+
       def swap_range(corrector, current, previous)
         current_range = declaration(current)
         previous_range = declaration(previous)
 
-        src1 = current_range.source
-        src2 = previous_range.source
-
-        corrector.replace(current_range, src2)
-        corrector.replace(previous_range, src1)
+        corrector.insert_before(previous_range, current_range.source)
+        corrector.remove(current_range)
       end
 
       def declaration(node)
         buffer = processed_source.buffer
-        begin_pos = node.source_range.begin_pos
+        begin_pos = range_by_whole_lines(node.source_range).begin_pos
         end_line = buffer.line_for_position(node.loc.expression.end_pos)
-        end_pos = buffer.line_range(end_line).end_pos
+        end_pos = range_by_whole_lines(buffer.line_range(end_line),
+                                       include_final_newline: true).end_pos
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
     end

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -133,4 +133,28 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields do
       RUBY
     end
   end
+
+  context "with multiple offenses" do
+    it "orders all fields alphabetically" do
+      expect_offense(<<~RUBY)
+        class SomeType < Types::BaseObject
+          field :id, Integer
+          field :some_field, Integer
+          field :field_too, Integer
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `field_too` should appear before `some_field`.
+          field :field, Integer
+          ^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `field` should appear before `field_too`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class SomeType < Types::BaseObject
+          field :field, Integer
+          field :field_too, Integer
+          field :id, Integer
+          field :some_field, Integer
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #63. 

Reimplemented the `swap_range` helper to avoid the tree clobbering.