### PR TITLE
Fix typo in LegacyDsl message

### DIFF
--- a/lib/rubocop/cop/graphql/legacy_dsl.rb
+++ b/lib/rubocop/cop/graphql/legacy_dsl.rb
@@ -29,7 +29,8 @@ module RuboCop
           )
         PATTERN
 
-        MSG = "Avoid using legacy based type-based definitions. Use class-based defintions instead."
+        MSG = "Avoid using legacy based type-based definitions. " \
+              "Use class-based definitions instead."
 
         def on_send(node)
           return unless node.parent.type == :block

--- a/spec/rubocop/cop/graphql/legacy_dsl_spec.rb
+++ b/spec/rubocop/cop/graphql/legacy_dsl_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::GraphQL::LegacyDsl do
     it "registers an offense" do
       expect_offense(<<~RUBY)
         User = GraphQL::Object.define do
-               ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using legacy based type-based definitions. Use class-based defintions instead.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using legacy based type-based definitions. Use class-based definitions instead.
                field :foo, type.String
         end
       RUBY


### PR DESCRIPTION
This fixes a small typo I noticed in the message for LegacyDsl.