### PR TITLE
[ExtractType]: add `has` prefix to default values for config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -77,6 +77,7 @@ GraphQL/ExtractType:
   MaxFields: 2
   Prefixes:
     - is
+    - has
     - with
     - avg
     - min

--- a/spec/rubocop/cop/graphql/extract_type_spec.rb
+++ b/spec/rubocop/cop/graphql/extract_type_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::GraphQL::ExtractType do
     RuboCop::Config.new(
       "GraphQL/ExtractType" => {
         "MaxFields" => 2,
-        "Prefixes" => %w[is avg min max]
+        "Prefixes" => %w[is has avg min max]
       }
     )
   end


### PR DESCRIPTION
Hey there! Thanks for publishing a great library! 

I have disabled `has` prefix in our project(e.g. `hasNextPage` and `hasPreviousPage` ), and since it is often used as a generic naming convention. You can also find a number of them in the [GitHub API](https://docs.github.com/en/graphql/overview/explorer).
This is a minor correction, but I thought it was acceptable to include it in the default prefixes.

