### PR TITLE
Fix `GraphQL/FieldHashKey` keyword detection when string key is used

### DIFF
--- a/lib/rubocop/cop/graphql/field_hash_key.rb
+++ b/lib/rubocop/cop/graphql/field_hash_key.rb
@@ -50,7 +50,7 @@ module RuboCop
           suggested_hash_key_name = hash_key_to_use(method_definition)
 
           return if suggested_hash_key_name.nil?
-          return if RuboCop::GraphQL::Field::CONFLICT_FIELD_NAMES.include?(suggested_hash_key_name)
+          return if conflict?(suggested_hash_key_name)
 
           add_offense(node, message: message(suggested_hash_key_name)) do |corrector|
             autocorrect(corrector, node)
@@ -58,6 +58,10 @@ module RuboCop
         end
 
         private
+
+        def conflict?(suggested_hash_key_name)
+          RuboCop::GraphQL::Field::CONFLICT_FIELD_NAMES.include?(suggested_hash_key_name.to_sym)
+        end
 
         def message(hash_key)
           format(MSG, hash_key: hash_key)

--- a/spec/rubocop/cop/graphql/field_hash_key_spec.rb
+++ b/spec/rubocop/cop/graphql/field_hash_key_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldHashKey do
             end
           end
         RUBY
+
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :next, String, null: true, resolver_method: :user_next
+
+            def user_next
+              object['next']
+            end
+          end
+        RUBY
       end
     end
   end


### PR DESCRIPTION
I would like to change it to consider not only the Symbol case but also the String case.