### PR TITLE
Allow method calls without explicit receiver in object descriptions

### DIFF
--- a/lib/rubocop/cop/graphql/object_description.rb
+++ b/lib/rubocop/cop/graphql/object_description.rb
@@ -26,11 +26,6 @@ module RuboCop
 
         MSG = "Missing type description"
 
-        # @!method has_i18n_description?(node)
-        def_node_matcher :has_i18n_description?, <<~PATTERN
-          (send nil? :description (send (const nil? :I18n) :t ...))
-        PATTERN
-
         # @!method interface?(node)
         def_node_matcher :interface?, <<~PATTERN
           (send nil? :include (const ...))
@@ -53,8 +48,7 @@ module RuboCop
         private
 
         def has_description?(node)
-          has_i18n_description?(node) ||
-            description_method_call?(node)
+          description_method_call?(node)
         end
 
         def child_nodes(node)

--- a/lib/rubocop/graphql/description_method.rb
+++ b/lib/rubocop/graphql/description_method.rb
@@ -20,7 +20,7 @@ module RuboCop
     module DescriptionMethod
       extend RuboCop::NodePattern::Macros
 
-      DESCRIPTION_STRING = "{({str|dstr|const} ...)|(send const ...)|(send ({str|dstr} ...) _)}"
+      DESCRIPTION_STRING = "{str|dstr|const|send}"
 
       # @!method description_method_call?(node)
       def_node_matcher :description_method_call?, <<~PATTERN

--- a/spec/rubocop/cop/graphql/object_description_spec.rb
+++ b/spec/rubocop/cop/graphql/object_description_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe RuboCop::Cop::GraphQL::ObjectDescription, :config do
         end
       end
 
+      context "when description is a method call" do
+        it "does not register an offense" do
+          expect_no_offenses(<<~RUBY)
+            class Types::UserType < Types::BaseObject
+              description t(:user_type)
+            end
+          RUBY
+        end
+      end
+
       context "when description is a constant hash" do
         it "does not register an offense" do
           expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR allows method calls without explicit receiver in object descriptions:
```ruby
class Types::UserType < Types::BaseObject
  description t(:user_type)
end
```

Currently method calls are allowed on constants and strings.

Also, this PR does some clean up:
* Special case for calling `I18n.t` (`:has_i18n_description?`) is not needed as it is covered by `(send const ...)` pattern in `DescriptionMethod`
* I simplified `DescriptionMethod::DESCRIPTION_STRING`. I believe this simplification is correct but please recheck. This is my first time with rubocop node patterns:
  1. `{({str|dstr|const} ...)|(send const ...)|(send ({str|dstr} ...) _)}` we start with this
  2. `{({str|dstr|const} ...)|(send {const|str|dstr} ...)}` combine `send`s
  3. `({str|dstr|const|send} ...)` it doesn't really matter who is the receiver of the call (allow `nil` receiver too)
  4. `{str|dstr|const|send}` remove redundant `...`