### PR TITLE
Check #authorized? for unused arguments

### DIFF
--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -3,7 +3,8 @@
 module RuboCop
   module Cop
     module GraphQL
-      # Arguments should either be listed explicitly or **rest should be in the resolve signature.
+      # Arguments should either be listed explicitly or **rest should be in the resolve signature
+      # (and similar methods, such as #authorized?).
       #
       # @example
       #   # good
@@ -14,6 +15,7 @@ module RuboCop
       #     argument :post_id, String, loads: Types::PostType, as: :article
       #     argument :comment_ids, String, loads: Types::CommentType
       #
+      #     def authorized?(arg1:, user:, article:, comments:); end
       #     def resolve(arg1:, user:, article:, comments:); end
       #   end
       #
@@ -46,6 +48,7 @@ module RuboCop
       #     argument :arg1, String, required: true
       #     argument :arg2, String, required: true
       #
+      #     def authorized?; end
       #     def resolve(arg1:); end
       #   end
       #
@@ -63,7 +66,7 @@ module RuboCop
       class UnusedArgument < Base
         extend AutoCorrector
 
-        MSG = "Argument%<ending>s `%<unresolved_args>s` should be listed in the resolve signature."
+        MSG = "Argument%<ending>s `%<unresolved_args>s` should be listed in the %<name>s signature."
 
         def on_class(node)
           resolve_method_node = find_resolve_method_node(node)
@@ -123,7 +126,8 @@ module RuboCop
           message = format(
             self.class::MSG,
             unresolved_args: unresolved_args_source,
-            ending: unresolved_args.size == 1 ? "" : "s"
+            ending: unresolved_args.size == 1 ? "" : "s",
+            name: node.method_name.to_s
           )
 
           add_offense(node, message: message) do |corrector|
@@ -182,7 +186,7 @@ module RuboCop
 
         # @!method resolve_method_definition(node)
         def_node_search :resolve_method_definition, <<~PATTERN
-          (def :resolve
+          (def {:resolve | :authorized?}
             (args ...) ...)
         PATTERN
       end


### PR DESCRIPTION
Extended the `UnusedArgument` cop to also check for arguments in the `#authorized?` callback (which should be the same as in the `#resolve` method). 