### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: [2.6, 2.7, "3.0", 3.1, 3.2]
         gemfile: [
           "gemfiles/rubocop_0.87.0.gemfile",
           "gemfiles/rubocop_0.89.0.gemfile",
@@ -27,8 +27,8 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: /home/runner/bundle
           key: bundle-${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ hashFiles(matrix.gemfile) }}-${{ hashFiles('**/*.gemspec') }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7


### PR DESCRIPTION
Also updates cache and checkout actions to v3.  Quotes 3.0 in the Ruby matrix to prevent truncation.

Runs green on my fork.