### PR TITLE
allow nested graphql folder for extract input type recommendation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -74,7 +74,7 @@ GraphQL/ExtractInputType:
   Description: 'Suggests using input type instead of many arguments'
   MaxArguments: 2
   Include:
-    - 'graphql/mutations/**/*.rb'
+    - '**/graphql/mutations/**/*.rb'
 
 GraphQL/ExtractType:
   Enabled: true


### PR DESCRIPTION
The [ExtractInputType: include only mutations fix](https://github.com/DmitryTsepelev/rubocop-graphql/pull/99) only works if the graphql folder is in the top directory.

Many place their graphql folder in the rails app directory, leading to this recommendation not occurring.
 
 Placing a wildcard in front should allow for a nested gql folder