### PR TITLE
[Fix #108] Handle heredocs when reordering code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - [PR#107](https://github.com/DmitryTsepelev/rubocop-graphql/pull/107) Make ExtractInputType check nested folders ([@arenclissold][])
+- [PR#109](https://github.com/DmitryTsepelev/rubocop-graphql/pull/109) [OrderedFields] [OrderedArguments] Handle heredocs when auto-correcting ([@Darhazer][])
 
 ## 0.18.0 (2022-10-30)
 

--- a/lib/rubocop/graphql/swap_range.rb
+++ b/lib/rubocop/graphql/swap_range.rb
@@ -16,10 +16,19 @@ module RuboCop
       def declaration(node)
         buffer = processed_source.buffer
         begin_pos = range_by_whole_lines(node.source_range).begin_pos
-        end_line = buffer.line_for_position(node.loc.expression.end_pos)
+        end_line = buffer.line_for_position(final_end_location(node).end_pos)
         end_pos = range_by_whole_lines(buffer.line_range(end_line),
                                        include_final_newline: true).end_pos
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
+      end
+
+      def final_end_location(start_node)
+        heredoc_endings =
+          start_node.each_node(:str, :dstr, :xstr)
+                    .select(&:heredoc?)
+                    .map { |node| node.loc.heredoc_end }
+
+        [start_node.source_range.end, *heredoc_endings].max_by(&:line)
       end
     end
   end

--- a/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_arguments_spec.rb
@@ -134,6 +134,31 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedArguments, :config do
     end
   end
 
+  context "when an unordered argument declaration uses heredoc" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class UpdateProfile < BaseMutation
+          argument :uuid, ID, required: true
+          argument :email, String, required: false, description: <<~DESC
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Arguments should be sorted in an alphabetical order within their section. Field `email` should appear before `uuid`.
+            heredoc description
+          DESC
+          argument :name, String, required: false
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class UpdateProfile < BaseMutation
+          argument :email, String, required: false, description: <<~DESC
+            heredoc description
+          DESC
+          argument :name, String, required: false
+          argument :uuid, ID, required: true
+        end
+      RUBY
+    end
+  end
+
   context "when an unordered argument declaration contains a block" do
     it "registers an offense" do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -130,6 +130,29 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
     end
   end
 
+  context "when a unordered field declaration uses heredocs" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class UserType < BaseType
+          field :phone, String, null: true
+          field :name, String, null: true, description: <<~HEREDOC
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `name` should appear before `phone`.
+            heredoc_example
+          HEREDOC
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class UserType < BaseType
+          field :name, String, null: true, description: <<~HEREDOC
+            heredoc_example
+          HEREDOC
+          field :phone, String, null: true
+        end
+      RUBY
+    end
+  end
+
   context "with multiple offenses" do
     it "orders all fields alphabetically" do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Fixed the `swap_range` method to support heredocs.
Copied the `final_end_location` from rubocop-rspec, where it's battle tested