### PR TITLE
🐛  `GraphQL/OrderedFields` doesn't behave correctly when there are spaces or blocks in between

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -112,7 +112,7 @@ GraphQL/OrderedFields:
   Enabled: true
   VersionAdded: '0.80'
   Description: 'Fields should be alphabetically sorted within groups'
-  Groups: false
+  Groups: true
 
 GraphQL/UnusedArgument:
   Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -112,6 +112,7 @@ GraphQL/OrderedFields:
   Enabled: true
   VersionAdded: '0.80'
   Description: 'Fields should be alphabetically sorted within groups'
+  Groups: false
 
 GraphQL/UnusedArgument:
   Enabled: true

--- a/lib/rubocop/cop/graphql/ordered_fields.rb
+++ b/lib/rubocop/cop/graphql/ordered_fields.rb
@@ -41,7 +41,6 @@ module RuboCop
 
         def on_class(node)
           field_declarations(node).each_cons(2) do |previous, current|
-            next unless consecutive_lines(previous, current)
             next if field_name(current) >= field_name(previous)
 
             register_offense(previous, current)
@@ -68,10 +67,6 @@ module RuboCop
           else
             node.first_argument.value.to_s
           end
-        end
-
-        def consecutive_lines(previous, current)
-          previous.source_range.last_line == current.source_range.first_line - 1
         end
 
         # @!method field_declarations(node)

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
     end
   end
 
-  context "when group config is disabled" do
+  context "when group config is false" do
     let(:config) do
       RuboCop::Config.new(
         "GraphQL/OrderedFields" => {

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -1,6 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
+  let(:config) do
+    RuboCop::Config.new(
+      "GraphQL/OrderedFields" => {
+        "Groups" => true
+      }
+    )
+  end
+
+  context "when there is a block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class UserType < BaseType
+          field :birthdate, Int, null: true do
+            description 'foo'
+          end
+          field :abc, String, null: true
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `abc` should appear before `birthdate`.
+        end
+      RUBY
+    end
+  end
+
   context "when fields are alphabetically sorted" do
     it "not registers an offense" do
       expect_no_offenses(<<~RUBY)
@@ -31,14 +53,13 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
   end
 
   context "when grouped fields are not alphabetically sorted" do
-    it "registers an offense" do
-      expect_offense(<<~RUBY)
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
         class UserType < BaseType
           field :birthdate, Int, null: true
           field :name, Staring, null: true
 
           field :email, String, null: true
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `email` should appear before `name`.
           field :phone, String, null: true
         end
       RUBY
@@ -108,7 +129,15 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
     end
   end
 
-  context "when fields are not consecutive" do
+  context "when group config is disabled" do
+    let(:config) do
+      RuboCop::Config.new(
+        "GraphQL/OrderedFields" => {
+          "Groups" => false
+        }
+      )
+    end
+
     context "when there are blocks" do
       it "registers an offense" do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
### Context

When there's spaces or blocks in between fields, the rubocop rule treats them as separate "groups". This is due to the `consecutive_line` check. While this kind of makes sense when looking at the code, it doesn't feel very intuitive from a user standpoint, and actually breaks for blocks being passed in.

I'm not too tied to this, but wanted to see if there was a good discussion or any ideas surrounding this.

Maybe we should just fix the blocks in between, rather than spaces and leave the groupings discussion for another time 🤔 

### Notes
I couldn't actually get the auto-correct to look cleanly for groups, and don't really know how to fix that one 😖 