### PR TITLE
NotAuthorizedNodeType on class method defined using class << self

### DIFF
--- a/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
+++ b/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe RuboCop::Cop::GraphQL::NotAuthorizedNodeType, :config do
       end
     end
 
+    context "when type has .authorized? check using class << self" do
+      specify do
+        expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+          class UserType < BaseType
+            implements GraphQL::Types::Relay::Node
+
+            field :uuid, ID, null: false
+
+            class << self
+              def authorized?(object, context)
+                super && object.owner == context[:viewer]
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
     context "when type has no .authorized? check" do
       specify do
         expect_offense(<<~RUBY, "graphql/types/user_type.rb")


### PR DESCRIPTION
PR to show failing tests when `authorized?` is defined at class level using `class << self`