### PR TITLE
Use `RESTRICT_ON_SEND`

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,8 +20,7 @@ jobs:
       matrix:
         ruby: ["3.0", 3.1, 3.2]
         gemfile: [
-          "gemfiles/rubocop_0.87.0.gemfile",
-          "gemfiles/rubocop_0.89.0.gemfile",
+          "gemfiles/rubocop_0.90.0.gemfile",
           "gemfiles/rubocop_1.0.gemfile",
           "gemfiles/rubocop_edge.gemfile"
         ]

--- a/gemfiles/rubocop_0.87.0.gemfile
+++ b/gemfiles/rubocop_0.87.0.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rubocop", "0.87.0"
-
-gemspec path: "../"

--- a/gemfiles/rubocop_0.90.0.gemfile
+++ b/gemfiles/rubocop_0.90.0.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "rubocop", "0.89.1"
+gem "rubocop", "0.90.0"
 
 gemspec path: "../"

--- a/lib/rubocop/cop/graphql/argument_description.rb
+++ b/lib/rubocop/cop/graphql/argument_description.rb
@@ -22,6 +22,7 @@ module RuboCop
         include RuboCop::GraphQL::NodePattern
 
         MSG = "Missing argument description"
+        RESTRICT_ON_SEND = %i[argument].freeze
 
         def on_send(node)
           return unless argument?(node)

--- a/lib/rubocop/cop/graphql/argument_name.rb
+++ b/lib/rubocop/cop/graphql/argument_name.rb
@@ -20,6 +20,7 @@ module RuboCop
       #
       class ArgumentName < Base
         include RuboCop::GraphQL::NodePattern
+        RESTRICT_ON_SEND = %i[argument].freeze
 
         using RuboCop::GraphQL::Ext::SnakeCase
 

--- a/lib/rubocop/cop/graphql/field_definitions.rb
+++ b/lib/rubocop/cop/graphql/field_definitions.rb
@@ -52,6 +52,8 @@ module RuboCop
         include RuboCop::GraphQL::Sorbet
         include RuboCop::GraphQL::Heredoc
 
+        RESTRICT_ON_SEND = %i[field].freeze
+
         # @!method field_kwargs(node)
         def_node_matcher :field_kwargs, <<~PATTERN
           (send nil? :field

--- a/lib/rubocop/cop/graphql/field_description.rb
+++ b/lib/rubocop/cop/graphql/field_description.rb
@@ -22,6 +22,7 @@ module RuboCop
         include RuboCop::GraphQL::NodePattern
 
         MSG = "Missing field description"
+        RESTRICT_ON_SEND = %i[field].freeze
 
         def on_send(node)
           return unless field_definition?(node)

--- a/lib/rubocop/cop/graphql/field_hash_key.rb
+++ b/lib/rubocop/cop/graphql/field_hash_key.rb
@@ -41,6 +41,7 @@ module RuboCop
         PATTERN
 
         MSG = "Use hash_key: %<hash_key>p"
+        RESTRICT_ON_SEND = %i[field].freeze
 
         def on_send(node)
           return unless field_definition?(node)

--- a/lib/rubocop/cop/graphql/field_method.rb
+++ b/lib/rubocop/cop/graphql/field_method.rb
@@ -40,6 +40,7 @@ module RuboCop
         PATTERN
 
         MSG = "Use method: :%<method_name>s"
+        RESTRICT_ON_SEND = %i[field].freeze
 
         def on_send(node)
           return unless field_definition?(node)

--- a/lib/rubocop/cop/graphql/field_name.rb
+++ b/lib/rubocop/cop/graphql/field_name.rb
@@ -29,6 +29,7 @@ module RuboCop
         using RuboCop::GraphQL::Ext::SnakeCase
 
         MSG = "Use snake_case for field names"
+        RESTRICT_ON_SEND = %i[field].freeze
 
         def on_send(node)
           return unless field_definition?(node)

--- a/lib/rubocop/cop/graphql/legacy_dsl.rb
+++ b/lib/rubocop/cop/graphql/legacy_dsl.rb
@@ -32,6 +32,7 @@ module RuboCop
 
         MSG = "Avoid using legacy based type-based definitions. " \
               "Use class-based definitions instead."
+        RESTRICT_ON_SEND = %i[define].freeze
 
         def on_send(node)
           return unless node.parent.block_type?

--- a/lib/rubocop/cop/graphql/multiple_field_definitions.rb
+++ b/lib/rubocop/cop/graphql/multiple_field_definitions.rb
@@ -32,6 +32,8 @@ module RuboCop
         include RuboCop::Cop::RangeHelp
         include RuboCop::GraphQL::Heredoc
 
+        RESTRICT_ON_SEND = %i[field].freeze
+
         def on_send(node)
           return unless field?(node)
 

--- a/lib/rubocop/cop/graphql/unnecessary_argument_camelize.rb
+++ b/lib/rubocop/cop/graphql/unnecessary_argument_camelize.rb
@@ -44,6 +44,7 @@ module RuboCop
         include RuboCop::GraphQL::NodePattern
 
         MSG = "Unnecessary argument camelize"
+        RESTRICT_ON_SEND = %i[argument].freeze
 
         def on_send(node)
           return unless argument?(node)

--- a/lib/rubocop/cop/graphql/unnecessary_field_alias.rb
+++ b/lib/rubocop/cop/graphql/unnecessary_field_alias.rb
@@ -25,6 +25,7 @@ module RuboCop
         include RuboCop::GraphQL::NodePattern
 
         MSG = "Unnecessary :%<kwarg>s configured"
+        RESTRICT_ON_SEND = %i[field].freeze
 
         def on_send(node)
           return unless field_definition?(node)

--- a/lib/rubocop/cop/graphql/unnecessary_field_camelize.rb
+++ b/lib/rubocop/cop/graphql/unnecessary_field_camelize.rb
@@ -22,6 +22,7 @@ module RuboCop
         include RuboCop::GraphQL::NodePattern
 
         MSG = "Unnecessary field camelize"
+        RESTRICT_ON_SEND = %i[field].freeze
 
         def on_send(node)
           return unless field_definition?(node)

--- a/rubocop-graphql.gemspec
+++ b/rubocop-graphql.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9"
 
-  spec.add_runtime_dependency "rubocop", ">= 0.87", "< 2"
+  spec.add_runtime_dependency "rubocop", ">= 0.90", "< 2"
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/8365.

This PR uses `RESTRICT_ON_SEND` to restrict callbacks `on_send` to specific method names only. https://docs.rubocop.org/rubocop/1.52/development.html#implementation

`RESTRICT_ON_SEND` has been introduced since RuboCop 0.90, so it bumps the required lowest runtime RuboCop dependency from 0.87 to 0.90. No runtime Ruby version incompatibilities between 0.87 and 0.90: https://docs.rubocop.org/rubocop/1.52/compatibility.html