### PR TITLE
Check a variety of base classes in the NotAuthorizedNodeType check

### DIFF
--- a/lib/rubocop/cop/graphql/not_authorized_node_type.rb
+++ b/lib/rubocop/cop/graphql/not_authorized_node_type.rb
@@ -48,11 +48,6 @@ module RuboCop
       class NotAuthorizedNodeType < Base
         MSG = ".authorized? should be defined for types implementing Node interface."
 
-        # @!method class_name(node)
-        def_node_matcher :class_name, <<~PATTERN
-          (const nil? $_)
-        PATTERN
-
         # @!method implements_node_type?(node)
         def_node_matcher :implements_node_type?, <<~PATTERN
           `(send nil? :implements
@@ -67,20 +62,33 @@ module RuboCop
           {`(:defs (:self) :authorized? ...) | `(:sclass (:self) `(:def :authorized? ...))}
         PATTERN
 
+        def on_module(node)
+          @parent_modules ||= []
+          @parent_modules << node.child_nodes[0].const_name
+        end
+
         def on_class(node)
-          return if ignored_class?(parent_class(node))
+          @parent_modules ||= []
+          return if possible_parent_classes(node).any? { |klass| ignored_class?(klass) }
+
+          @parent_modules << node.child_nodes[0].const_name
 
           add_offense(node) if implements_node_type?(node) && !has_authorized_method?(node)
         end
 
         private
 
-        def parent_class(node)
-          node.child_nodes[1]
+        def possible_parent_classes(node)
+          klass = node.child_nodes[1].const_name
+
+          return [klass] if node.child_nodes[1].absolute?
+
+          parent_module = "#{@parent_modules.join('::')}::"
+          [klass, parent_module + klass]
         end
 
-        def ignored_class?(node)
-          cop_config["SafeBaseClasses"].include?(String(class_name(node)))
+        def ignored_class?(klass)
+          cop_config["SafeBaseClasses"].include?(klass)
         end
       end
     end

--- a/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
+++ b/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::GraphQL::NotAuthorizedNodeType, :config do
   let(:config) do
     RuboCop::Config.new(
       "GraphQL/NotAuthorizedNodeType" => {
-        "SafeBaseClasses" => ["BaseUserType"]
+        "SafeBaseClasses" => ["BaseUserType", "Types::OtherBaseUserType"]
       }
     )
   end
@@ -86,6 +86,54 @@ RSpec.describe RuboCop::Cop::GraphQL::NotAuthorizedNodeType, :config do
               implements GraphQL::Types::Relay::Node
 
               field :uuid, ID, null: false
+            end
+          RUBY
+        end
+
+        specify do
+          expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+            module Types
+              class UserType < BaseUserType
+                implements GraphQL::Types::Relay::Node
+
+                field :uuid, ID, null: false
+              end
+            end
+          RUBY
+        end
+
+        specify do
+          expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+            module Types
+              class UserType < ::BaseUserType
+                implements GraphQL::Types::Relay::Node
+
+                field :uuid, ID, null: false
+              end
+            end
+          RUBY
+        end
+
+        specify do
+          expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+            module Types
+              class UserType < OtherBaseUserType
+                implements GraphQL::Types::Relay::Node
+
+                field :uuid, ID, null: false
+              end
+            end
+          RUBY
+        end
+
+        specify do
+          expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+            module Types
+              class UserType < Types::OtherBaseUserType
+                implements GraphQL::Types::Relay::Node
+
+                field :uuid, ID, null: false
+              end
             end
           RUBY
         end


### PR DESCRIPTION
Closes #142

If I add Types::BaseUserType to SafeBaseClasses I'd expect all of following to pass the cop:

1.  Absolute reference

```ruby
module Types
  class UserType < ::Types::BaseUserType
    implements GraphQL::Types::Relay::Node

    field :uuid, ID, null: false
  end
end
```

2. Relative reference to the "root" namespace

```ruby
module Types
  class UserType < Types::BaseUserType
    implements GraphQL::Types::Relay::Node

    field :uuid, ID, null: false
  end
end
```

3. Relative reference within the module

```ruby
module Types
  class UserType < BaseUserType
    implements GraphQL::Types::Relay::Node

    field :uuid, ID, null: false
  end
end
```

The only one that currently passes the cop is case 2.

These are all valid ruby, but could lead to confusion/frustration when trying to sort out GraphQL authorization. I'd propose checking a list of possible parent classes in this instance.

In case 1 we can just check `Types::BaseUserType` is our `SafeBaseClasses` list.

In case 2 we need to check if either `Types::BaseUserType` or `Types::Types::BaseUserType` is in our list.

Finally in case 3 we need to check if either `BaseUserType` or `Types::BaseUserType` is in our list.

I don't think we can see from the AST which other classes have been defined in the code, so checking for the two possible permutations is required for this cop to be robust.