### PR TITLE
Allow can_can_action and pundit_role to cause NotAuthorizedNodeType to pass

### DIFF
--- a/lib/rubocop/cop/graphql/not_authorized_node_type.rb
+++ b/lib/rubocop/cop/graphql/not_authorized_node_type.rb
@@ -10,6 +10,9 @@ module RuboCop
       # If `.authorized?` is defined in a parent class, you can add parent to the "SafeBaseClasses"
       # to avoid offenses in children.
       #
+      # This cop also checks the `can_can_action` or `pundit_role` methods that
+      # can be used as part of the Ruby GraphQL Pro.
+      #
       # @example
       #   # good
       #
@@ -37,6 +40,26 @@ module RuboCop
       #     end
       #   end
       #
+      #   # good
+      #
+      #   class UserType < BaseType
+      #     implements GraphQL::Types::Relay::Node
+      #
+      #     pundit_role :staff
+      #
+      #     field :uuid, ID, null: false
+      #   end
+      #
+      #   # good
+      #
+      #   class UserType < BaseType
+      #     implements GraphQL::Types::Relay::Node
+      #
+      #     can_can_action :staff
+      #
+      #     field :uuid, ID, null: false
+      #   end
+      #
       #   # bad
       #
       #   class UserType < BaseType
@@ -62,6 +85,16 @@ module RuboCop
                   (const nil? :GraphQL) :Types) :Relay) :Node))
         PATTERN
 
+        # @!method has_can_can_action?(node)
+        def_node_matcher :has_can_can_action?, <<~PATTERN
+          `(send nil? :can_can_action sym_type?)
+        PATTERN
+
+        # @!method has_pundit_role?(node)
+        def_node_matcher :has_pundit_role?, <<~PATTERN
+          `(send nil? :pundit_role sym_type?)
+        PATTERN
+
         # @!method has_authorized_method?(node)
         def_node_matcher :has_authorized_method?, <<~PATTERN
           {`(:defs (:self) :authorized? ...) | `(:sclass (:self) `(:def :authorized? ...))}
@@ -70,7 +103,9 @@ module RuboCop
         def on_class(node)
           return if ignored_class?(parent_class(node))
 
-          add_offense(node) if implements_node_type?(node) && !has_authorized_method?(node)
+          if implements_node_type?(node) && !has_authorized_method?(node) && !has_can_can_action?(node) && !has_pundit_role?(node)
+            add_offense(node)
+          end
         end
 
         private

--- a/lib/rubocop/cop/graphql/not_authorized_node_type.rb
+++ b/lib/rubocop/cop/graphql/not_authorized_node_type.rb
@@ -118,6 +118,7 @@ module RuboCop
         def possible_parent_classes(node)
           klass = node.child_nodes[1].const_name
 
+          return [] if klass.nil?
           return [klass] if node.child_nodes[1].absolute?
 
           parent_module = "#{@parent_modules.join('::')}::"

--- a/lib/rubocop/cop/graphql/not_authorized_node_type.rb
+++ b/lib/rubocop/cop/graphql/not_authorized_node_type.rb
@@ -87,12 +87,12 @@ module RuboCop
 
         # @!method has_can_can_action?(node)
         def_node_matcher :has_can_can_action?, <<~PATTERN
-          `(send nil? :can_can_action sym_type?)
+          `(send nil? :can_can_action {nil_type? sym_type?})
         PATTERN
 
         # @!method has_pundit_role?(node)
         def_node_matcher :has_pundit_role?, <<~PATTERN
-          `(send nil? :pundit_role sym_type?)
+          `(send nil? :pundit_role {nil_type? sym_type?})
         PATTERN
 
         # @!method has_authorized_method?(node)

--- a/lib/rubocop/cop/graphql/not_authorized_node_type.rb
+++ b/lib/rubocop/cop/graphql/not_authorized_node_type.rb
@@ -106,12 +106,14 @@ module RuboCop
 
           @parent_modules << node.child_nodes[0].const_name
 
-          if implements_node_type?(node) && !has_authorized_method?(node) && !has_can_can_action?(node) && !has_pundit_role?(node)
-            add_offense(node)
-          end
+          add_offense(node) if implements_node_type?(node) && !implements_authorization?(node)
         end
 
         private
+
+        def implements_authorization?(node)
+          has_authorized_method?(node) || has_can_can_action?(node) || has_pundit_role?(node)
+        end
 
         def possible_parent_classes(node)
           klass = node.child_nodes[1].const_name

--- a/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
+++ b/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
@@ -104,6 +104,18 @@ RSpec.describe RuboCop::Cop::GraphQL::NotAuthorizedNodeType, :config do
           end
         RUBY
       end
+
+      specify do
+        expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+          class UserType
+            implements GraphQL::Types::Relay::Node
+
+            pundit_role nil
+
+            field :uuid, ID, null: false
+          end
+        RUBY
+      end
     end
 
     context "when type has a can_can_action" do
@@ -113,6 +125,18 @@ RSpec.describe RuboCop::Cop::GraphQL::NotAuthorizedNodeType, :config do
             implements GraphQL::Types::Relay::Node
 
             can_can_action :read
+
+            field :uuid, ID, null: false
+          end
+        RUBY
+      end
+
+      specify do
+        expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+          class UserType
+            implements GraphQL::Types::Relay::Node
+
+            can_can_action nil
 
             field :uuid, ID, null: false
           end

--- a/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
+++ b/spec/rubocop/cop/graphql/not_authorized_node_type_spec.rb
@@ -91,5 +91,33 @@ RSpec.describe RuboCop::Cop::GraphQL::NotAuthorizedNodeType, :config do
         end
       end
     end
+
+    context "when type has a pundit_role" do
+      specify do
+        expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+          class UserType
+            implements GraphQL::Types::Relay::Node
+
+            pundit_role :staff
+
+            field :uuid, ID, null: false
+          end
+        RUBY
+      end
+    end
+
+    context "when type has a can_can_action" do
+      specify do
+        expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+          class UserType
+            implements GraphQL::Types::Relay::Node
+
+            can_can_action :read
+
+            field :uuid, ID, null: false
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds in a node matcher looking for can_can_action or pundit_role to be called on an object implementing `GraphQL::Types::Relay::Node`.  This appears to be the minimum requirement to [add in pundit ](https://graphql-ruby.org/authorization/pundit_integration.html#authorizing-objects )or [cancancan auth](https://graphql-ruby.org/authorization/can_can_integration.html#authorizing-objects) to a GraphQL type.

closes #140