### PR TITLE
Fix false-positives for `GraphQL/ArgumentDescription` when there's additional nodes in the Argument init block

### DIFF
--- a/lib/rubocop/cop/graphql/unnecessary_field_alias.rb
+++ b/lib/rubocop/cop/graphql/unnecessary_field_alias.rb
@@ -35,7 +35,7 @@ module RuboCop
           if (unnecessary_kwarg = validate_kwargs(field))
             message = format(self.class::MSG, kwarg: unnecessary_kwarg)
             add_offense(node, message: message) do |corrector|
-              kwarg_node = node.arguments.last.pairs.find do |pair|
+              kwarg_node = node.last_argument.pairs.find do |pair|
                 pair.key.value == unnecessary_kwarg.to_sym
               end
               corrector.remove_preceding(kwarg_node, 2)

--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -132,7 +132,7 @@ module RuboCop
 
           add_offense(node, message: message) do |corrector|
             if node.arguments?
-              corrector.insert_after(arg_end(node.arguments.last), ", #{unresolved_args_source}")
+              corrector.insert_after(arg_end(node.last_argument), ", #{unresolved_args_source}")
             else
               corrector.insert_after(method_name(node), "(#{unresolved_args_source})")
             end

--- a/lib/rubocop/graphql/argument/block.rb
+++ b/lib/rubocop/graphql/argument/block.rb
@@ -12,7 +12,7 @@ module RuboCop
           (block
             (send nil? :argument ...)
             (args ...)
-            $...
+            {(begin $...)|$...}
           )
         PATTERN
 

--- a/spec/rubocop/cop/graphql/argument_description_spec.rb
+++ b/spec/rubocop/cop/graphql/argument_description_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe RuboCop::Cop::GraphQL::ArgumentDescription, :config do
       RUBY
     end
 
+    context "when block also contains something else" do
+      it "not registers an offense" do
+        expect_no_offenses(<<~RUBY)
+          class BanUser < BaseMutation
+            argument :uuid, ID, required: true do
+              description "UUID of the user to ban"
+              deprecation_reason "because"
+            end
+          end
+        RUBY
+      end
+    end
+
     context "when description is set with block argument" do
       it "not registers an offense" do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This is a fix for [Issue 148](https://github.com/DmitryTsepelev/rubocop-graphql/issues/148)

Addes a spec scenario for demonstrating the issue we ran into and adds the same matcher fix that was used in #41 to fix the same issue with `GraphQL/FieldDescription`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206122287181778