### PR TITLE
Add GraphQL department excludes to ObjectDescription cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -134,6 +134,8 @@ GraphQL/ObjectDescription:
   VersionAdded: '0.3.0'
   Description: 'Ensures all types have a description'
   Exclude:
+    - "spec/**/*"
+    - "test/**/*"
     - '**/*_schema.rb'
     - '**/base_*.rb'
     - '**/graphql/query_context.rb'


### PR DESCRIPTION
This is necessary because the Exclude configuration on the cop overrides (and is not merged with) the Exclude configuration on the department.

(See: https://docs.rubocop.org/rubocop/configuration.html#inheritance-of-hashes-vs-other-types)

Fixes #95 