### PR TITLE
feat: use rubocop to calculate code length for ResolverMethodLength

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -128,6 +128,7 @@ GraphQL/ResolverMethodLength:
   Max: 10
   CountComments: false
   ExcludedMethods: []
+  CountAsOne: []
 
 GraphQL/ObjectDescription:
   Enabled: true

--- a/lib/rubocop/cop/graphql/resolver_method_length.rb
+++ b/lib/rubocop/cop/graphql/resolver_method_length.rb
@@ -23,9 +23,11 @@ module RuboCop
           return if excluded_methods.include?(String(node.method_name))
 
           if field_is_defined?(node)
-            length = code_length(node)
+            return if node.line_count <= max_length
 
-            return unless length > max_length
+            calculator = build_code_length_calculator(node)
+            length = calculator.calculate
+            return if length <= max_length
 
             add_offense(node, message: message(length))
           end
@@ -33,10 +35,6 @@ module RuboCop
         alias on_defs on_def
 
         private
-
-        def code_length(node)
-          node.source.lines[1..-2].count { |line| !irrelevant_line(line) }
-        end
 
         def field_is_defined?(node)
           node.parent

--- a/spec/rubocop/cop/graphql/resolver_method_length_spec.rb
+++ b/spec/rubocop/cop/graphql/resolver_method_length_spec.rb
@@ -56,6 +56,35 @@ RSpec.describe RuboCop::Cop::GraphQL::ResolverMethodLength, :config do
         RUBY
       end
     end
+
+    context "when CountAsOne is set to [:hash]" do
+      let(:config) do
+        RuboCop::Config.new(
+          "GraphQL/ResolverMethodLength" => {
+            "Max" => 2,
+            "ExcludedMethods" => [],
+            "CountAsOne" => ['hash']
+          }
+        )
+      end
+
+      it "registers no offenses" do
+        expect_no_offenses(<<~RUBY)
+          class UserType < BaseType
+            field :first_name, String, null: true
+  
+            def first_name
+              line_1
+              {
+                a: 1,
+                b: 2,
+                c: 3
+              }
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context "when method is not a GraphQL resolver method" do

--- a/spec/rubocop/cop/graphql/resolver_method_length_spec.rb
+++ b/spec/rubocop/cop/graphql/resolver_method_length_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::GraphQL::ResolverMethodLength, :config do
       end
     end
 
-    context "when CountAsOne is set to [:hash]" do
+    context "when CountAsOne is set to ['hash']" do
       let(:config) do
         RuboCop::Config.new(
           "GraphQL/ResolverMethodLength" => {


### PR DESCRIPTION
This will make the `ResolverMethodLength` cop behave the same way other base rubocop code length metrics work, such as https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/MethodLength and https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/ModuleLength

Adds the `CountAsOne` configuration option that can accept ’array’, ‘hash’, ‘heredoc’, and ‘method_call’