### PR TITLE
Add `SuggestExtensions: false` in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.0
+  SuggestExtensions: false
 
 GraphQL/ObjectDescription:
   Enabled: false


### PR DESCRIPTION
```
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-rake (https://rubygems.org/gems/rubocop-rake)
  * rubocop-rspec (https://rubygems.org/gems/rubocop-rspec)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```