### PR TITLE
Fix FieldDefinitions to preserve comments when autocorrecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [PR#163](https://github.com/DmitryTsepelev/rubocop-graphql/pull/163) Fix FieldDefinitions to preserve comments when autocorrecting ([@fatkodima][])
 - [PR#165](https://github.com/DmitryTsepelev/rubocop-graphql/pull/165) Drop support for rubocop < 1.50 ([@fatkodima][])
 - [PR#164](https://github.com/DmitryTsepelev/rubocop-graphql/pull/164) Fix FieldDefinitions autocorrection for fields with squished heredocs ([@fatkodima][])
 

--- a/spec/rubocop/cop/graphql/field_definitions_spec.rb
+++ b/spec/rubocop/cop/graphql/field_definitions_spec.rb
@@ -968,6 +968,52 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldDefinitions, :config do
           end
         end
       end
+
+      context "when resolver methods have comments" do
+        it "registers offenses" do
+          expect_offense(<<~RUBY)
+            class UserType < BaseType
+              field :first_name, String, null: true
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Define resolver method after field definition.
+              field :last_name, String, null: true
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Define resolver method after field definition.
+
+              # Comment.
+              sig { returns(String) }
+              def first_name
+                object.contact_data.first_name
+              end
+
+              # Multiline
+              # comment.
+              def last_name
+                object.contact_data.last_name
+              end
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            class UserType < BaseType
+              field :first_name, String, null: true
+
+              # Comment.
+              sig { returns(String) }
+              def first_name
+                object.contact_data.first_name
+              end
+
+              field :last_name, String, null: true
+
+              # Multiline
+              # comment.
+              def last_name
+                object.contact_data.last_name
+              end
+
+            end
+          RUBY
+        end
+      end
     end
 
     context "when there are multiple field definitions" do


### PR DESCRIPTION
Currently, `FieldDefinitions` when autocorrects, does not preserve the comments. This PR fixes that.

Also, tests are failing for rubocop 1.0 because when autocorrecting, some extra new lines are present in one version, but not the other. Wdyt about dropping rubocop < 1.50, for example?