### PR TITLE
Fix FieldDefinitions autocorrection for fields with squished heredocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#164](https://github.com/DmitryTsepelev/rubocop-graphql/pull/164) Fix FieldDefinitions autocorrection for fields with squished heredocs ([@fatkodima][])
+
 ## 1.5.2 (2024-06-01)
 
 - [PR#157](https://github.com/DmitryTsepelev/rubocop-graphql/pull/157) Optimize OrderedArguments and FieldDefinitions cops ([@fatkodima][])

--- a/lib/rubocop/graphql/heredoc.rb
+++ b/lib/rubocop/graphql/heredoc.rb
@@ -8,15 +8,22 @@ module RuboCop
       end
 
       def range_including_heredoc(node)
-        field = RuboCop::GraphQL::Field.new(node)
-        last_heredoc = field.kwargs.instance_variable_get(:@nodes).reverse.find do |kwarg|
-                         heredoc?(kwarg.value)
-                       end&.value
+        last_heredoc = find_last_heredoc(node)
 
         range = node.source_range
         range = range.join(last_heredoc.loc.heredoc_end) if last_heredoc
 
         range_by_whole_lines(range)
+      end
+
+      private
+
+      def find_last_heredoc(node)
+        # Do a cheap check first.
+        return nil unless node.source.include?("<<")
+
+        heredocs = node.descendants.select { |descendant| heredoc?(descendant) }
+        heredocs.max_by { |heredoc| heredoc.loc.heredoc_end }
       end
     end
   end


### PR DESCRIPTION
`FieldDefinitions` fails to correctly autocorrect in the following case:

```ruby
class UserType < BaseType
  field :first_name, String, null: true, description: <<~DESC.squish
    First name.
  DESC
  field :last_name, String, null: true

  def last_name
    object.contact_data.last_name
  end

  def first_name
    object.contact_data.first_name
  end
end
```

It autocorrects to:

```ruby
class UserType < BaseType
  field :first_name, String, null: true, description: <<~DESC.squish

  def first_name
    object.contact_data.first_name
  end

    First name.
  DESC
  field :last_name, String, null: true

  def last_name
    object.contact_data.last_name
  end
end
```