### PR TITLE
Remove a deprecated RuboCop's API

### DIFF
--- a/lib/rubocop/cop/graphql/resolver_method_length.rb
+++ b/lib/rubocop/cop/graphql/resolver_method_length.rb
@@ -8,7 +8,6 @@ module RuboCop
       #
       # The maximum allowed length is configurable using the Max option.
       class ResolverMethodLength < Base
-        include RuboCop::Cop::ConfigurableMax
         include RuboCop::Cop::CodeLength
 
         MSG = "ResolverMethod has too many lines. [%<total>d/%<max>d]"


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/9471.

This PR removes a deprecated `RuboCop::Cop::ConfigurableMax` module.

The `exclude_limit 'Max'` used instead of the deprecated API is defined in `RuboCop::Cop::CodeLength` mixin: https://github.com/rubocop/rubocop/blob/v1.65.0/lib/rubocop/cop/mixin/code_length.rb#L11

So it is sufficient to simply remove the deprecated API.