### PR TITLE
Suppress RuboCop offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ GraphQL/MaxDepthSchema:
     - lib/rubocop/cop/graphql/max_complexity_schema.rb
     - lib/rubocop/cop/graphql/max_depth_schema.rb
 
+InternalAffairs/OnSendWithoutOnCSend:
+  Enabled: false
+
 # FIXME: Workaround for a false positive caused by this cop when using `bundle exec rake`.
 InternalAffairs/UndefinedConfig:
   Enabled: false

--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -103,7 +103,7 @@ module RuboCop
 
         def find_unresolved_args(method_node, declared_arg_nodes)
           resolve_method_kwargs = method_node.arguments.select do |arg|
-            arg.kwarg_type? || arg.kwoptarg_type?
+            arg.type?(:kwarg, :kwoptarg)
           end
           resolve_method_kwargs_names = resolve_method_kwargs.map do |node|
             node.node_parts[0]
@@ -116,7 +116,7 @@ module RuboCop
 
         def ignore_arguments_type?(resolve_method_node)
           resolve_method_node.arguments.any? do |arg|
-            arg.arg_type? || arg.kwrestarg_type? || arg.forward_arg_type?
+            arg.type?(:arg, :kwrestarg, :forward_arg)
           end
         end
 
@@ -172,11 +172,11 @@ module RuboCop
         end
 
         def scope_changing_syntax?(node)
-          node.def_type? || node.defs_type? || node.class_type? || node.module_type?
+          node.type?(:def, :defs, :class, :module)
         end
 
         def block_or_lambda?(node)
-          node.block_type? || node.lambda_type?
+          node.type?(:block, :lambda)
         end
 
         # @!method argument_declaration?(node)

--- a/lib/rubocop/graphql/heredoc.rb
+++ b/lib/rubocop/graphql/heredoc.rb
@@ -4,7 +4,7 @@ module RuboCop
   module GraphQL
     module Heredoc
       def heredoc?(node)
-        (node.str_type? || node.dstr_type?) && node.heredoc?
+        node.type?(:str, :dstr) && node.heredoc?
       end
 
       def range_including_heredoc(node)


### PR DESCRIPTION
This PR suppresses the following `InternalAffairs/OnSendWithoutOnCSend and `InternalAffairs/NodeTypeMultiplePredicates` offenses:

```console
lib/rubocop/cop/graphql/unnecessary_field_camelize.rb:27:9:
C: InternalAffairs/OnSendWithoutOnCSend: Cop defines on_send but not on_csend.
        def on_send(node) ...
        ^^^^^^^^^^^^^^^^^
lib/rubocop/cop/graphql/unused_argument.rb:106:13:
C: [Correctable] InternalAffairs/NodeTypeMultiplePredicates: Use arg.type?(:kwarg, :kwoptarg) instead of checking for multiple node types.
            arg.kwarg_type? || arg.kwoptarg_type?
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

`InternalAffairs/OnSendWithoutOnCSend` is disabled in `.rubocop.yml` as it doesn't seem useful for `rubocop-graphql`, which primarily focuses on DSLs that do not assume a receiver.

`InternalAffairs/NodeTypeMultiplePredicates` is auto-corrected to enforce style consistency.