### PR TITLE
Add GraphQL/ContextWriteInType cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `GraphQL/ContextWriteInType` cop to detect writes to `context` in GraphQL types (disabled by default)
+
 ## 1.5.6 (2025-06-07)
 
 - [PR#177](https://github.com/DmitryTsepelev/rubocop-graphql/pull/177) Do not use ExtractType in mutations ([@DmitryTsepelev][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -21,6 +21,13 @@ GraphQL/ArgumentUniqueness:
   VersionAdded: '0.11.0'
   Description: 'This cop enforces arguments to be defined once per block'
 
+GraphQL/ContextWriteInType:
+  Enabled: false
+  VersionAdded: '<<next>>'
+  Description: 'Detects writes to context in GraphQL types, which mutates shared state'
+  Include:
+    - '**/graphql/types/**/*'
+
 GraphQL/ExtractInputType:
   Enabled: true
   VersionAdded: '0.2.0'

--- a/lib/rubocop/cop/graphql/context_write_in_type.rb
+++ b/lib/rubocop/cop/graphql/context_write_in_type.rb
@@ -41,7 +41,8 @@ module RuboCop
       #   end
       #
       class ContextWriteInType < Base
-        MSG = "Avoid writing to `context` in GraphQL types. Mutating shared state can lead to unexpected behavior."
+        MSG = "Avoid writing to `context` in GraphQL types. Mutating shared state can lead " \
+              "to unexpected behavior."
 
         RESTRICT_ON_SEND = %i[[]= merge! store].freeze
 

--- a/lib/rubocop/cop/graphql/context_write_in_type.rb
+++ b/lib/rubocop/cop/graphql/context_write_in_type.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GraphQL
+      # Detects writes to the `context` object within GraphQL types.
+      # Writing to `context` mutates shared state across the query execution,
+      # which can lead to unexpected behavior and makes code harder to reason about.
+      #
+      # This cop is disabled by default.
+      #
+      # @example
+      #   # bad
+      #   class UserType < BaseType
+      #     field :name, String, null: false
+      #
+      #     def name
+      #       context[:current_user] = object.user
+      #       object.name
+      #     end
+      #   end
+      #
+      #   # bad
+      #   class UserType < BaseType
+      #     field :name, String, null: false
+      #
+      #     def name
+      #       context.merge!(current_user: object.user)
+      #       object.name
+      #     end
+      #   end
+      #
+      #   # good
+      #   class UserType < BaseType
+      #     field :name, String, null: false
+      #
+      #     def name
+      #       viewer = context[:current_user]
+      #       object.name
+      #     end
+      #   end
+      #
+      class ContextWriteInType < Base
+        MSG = "Avoid writing to `context` in GraphQL types. Mutating shared state can lead to unexpected behavior."
+
+        RESTRICT_ON_SEND = %i[[]= merge! store].freeze
+
+        # @!method context_write?(node)
+        def_node_matcher :context_write?, <<~PATTERN
+          (send (send nil? :context) {:[]= :merge! :store} ...)
+        PATTERN
+
+        def on_send(node)
+          return unless context_write?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/graphql/unused_argument.rb
+++ b/lib/rubocop/cop/graphql/unused_argument.rb
@@ -172,7 +172,7 @@ module RuboCop
         end
 
         def scope_changing_syntax?(node)
-          node.type?(:def, :defs, :class, :module)
+          node.type?(:any_def, :class, :module)
         end
 
         def block_or_lambda?(node)

--- a/lib/rubocop/cop/graphql_cops.rb
+++ b/lib/rubocop/cop/graphql_cops.rb
@@ -3,6 +3,7 @@
 require_relative "graphql/argument_description"
 require_relative "graphql/argument_name"
 require_relative "graphql/argument_uniqueness"
+require_relative "graphql/context_write_in_type"
 require_relative "graphql/extract_input_type"
 require_relative "graphql/extract_type"
 require_relative "graphql/field_definitions"

--- a/spec/rubocop/cop/graphql/context_write_in_type_spec.rb
+++ b/spec/rubocop/cop/graphql/context_write_in_type_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::GraphQL::ContextWriteInType, :config do
+  context "when writing to context with bracket assignment" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY, "graphql/types/user_type.rb")
+        class UserType < BaseType
+          field :name, String, null: false
+
+          def name
+            context[:current_user] = object.user
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid writing to `context` in GraphQL types. Mutating shared state can lead to unexpected behavior.
+            object.name
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when writing to context with merge!" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY, "graphql/types/user_type.rb")
+        class UserType < BaseType
+          field :name, String, null: false
+
+          def name
+            context.merge!(current_user: object.user)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid writing to `context` in GraphQL types. Mutating shared state can lead to unexpected behavior.
+            object.name
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when writing to context with store" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY, "graphql/types/user_type.rb")
+        class UserType < BaseType
+          field :name, String, null: false
+
+          def name
+            context.store(:current_user, object.user)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid writing to `context` in GraphQL types. Mutating shared state can lead to unexpected behavior.
+            object.name
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when reading from context" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+        class UserType < BaseType
+          field :name, String, null: false
+
+          def name
+            viewer = context[:current_user]
+            object.name
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when calling other methods on context" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+        class UserType < BaseType
+          field :name, String, null: false
+
+          def name
+            context.fetch(:current_user)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when writing to a different object with bracket assignment" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY, "graphql/types/user_type.rb")
+        class UserType < BaseType
+          field :name, String, null: false
+
+          def name
+            hash = {}
+            hash[:key] = "value"
+            object.name
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Add a new cop that detects writes to the `context` object in GraphQL type definitions. Writing to `context` mutates shared state across the query execution, which can lead to unexpected behavior.

The cop detects `context[]=`, `context.merge!`, and `context.store` calls. It is disabled by default and scoped to type files.

This is currently Disabled by default as it's a breaking change, but could be added to the list of on by default cops. 

I think mutating the context in type is very error prone and should be avoided. I figured this should live in this gem, rather than just our code base.