### PR TITLE
fix(ordered_fields): scope field checks to direct class/module owner

### DIFF
--- a/lib/rubocop/cop/graphql/ordered_fields.rb
+++ b/lib/rubocop/cop/graphql/ordered_fields.rb
@@ -67,7 +67,13 @@ module RuboCop
         end
 
         def direct_child_field?(field_node, class_node)
-          field_node.each_ancestor(:class, :module).first == class_node
+          return false unless field_node.each_ancestor(:class, :module).first == class_node
+
+          field_node.each_ancestor(:block).none? do |block_ancestor|
+            next false if block_ancestor.each_ancestor(:class, :module).first != class_node
+
+            block_ancestor.send_node.method_name != :field
+          end
         end
 
         def consecutive_fields(previous, current)

--- a/lib/rubocop/cop/graphql/ordered_fields.rb
+++ b/lib/rubocop/cop/graphql/ordered_fields.rb
@@ -50,7 +50,7 @@ module RuboCop
         PATTERN
 
         def on_class(node)
-          field_declarations(node).each_cons(2) do |previous, current|
+          direct_field_declarations(node).each_cons(2) do |previous, current|
             next unless consecutive_fields(previous, current)
             next if correct_order?(field_name(previous), field_name(current))
 
@@ -61,6 +61,14 @@ module RuboCop
         alias on_module on_class
 
         private
+
+        def direct_field_declarations(node)
+          field_declarations(node).select { |field| direct_child_field?(field, node) }
+        end
+
+        def direct_child_field?(field_node, class_node)
+          field_node.each_ancestor(:class, :module).first == class_node
+        end
 
         def consecutive_fields(previous, current)
           return true if cop_config["Groups"] == false

--- a/lib/rubocop/cop/graphql/ordered_fields.rb
+++ b/lib/rubocop/cop/graphql/ordered_fields.rb
@@ -50,17 +50,32 @@ module RuboCop
         PATTERN
 
         def on_class(node)
-          direct_field_declarations(node).each_cons(2) do |previous, current|
+          check_field_ordering(direct_field_declarations(node))
+        end
+
+        alias on_module on_class
+
+        def on_block(node)
+          return if node.method?(:field)
+          return unless node.each_ancestor(:class, :module).any?
+
+          fields = field_declarations(node).select { |f| f.each_ancestor(:block).first == node }
+          check_field_ordering(fields)
+        end
+
+        alias on_itblock on_block
+        alias on_numblock on_block
+
+        private
+
+        def check_field_ordering(fields)
+          fields.each_cons(2) do |previous, current|
             next unless consecutive_fields(previous, current)
             next if correct_order?(field_name(previous), field_name(current))
 
             register_offense(previous, current)
           end
         end
-
-        alias on_module on_class
-
-        private
 
         def direct_field_declarations(node)
           field_declarations(node).select { |field| direct_child_field?(field, node) }

--- a/lib/rubocop/cop/graphql/ordered_fields.rb
+++ b/lib/rubocop/cop/graphql/ordered_fields.rb
@@ -72,7 +72,7 @@ module RuboCop
           field_node.each_ancestor(:block).none? do |block_ancestor|
             next false if block_ancestor.each_ancestor(:class, :module).first != class_node
 
-            block_ancestor.send_node.method_name != :field
+            !block_ancestor.method?(:field)
           end
         end
 

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -454,7 +454,7 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
       RUBY
     end
 
-    it "still registers an offense for out-of-order top-level fields alongside a with_options block" do
+    it "still registers an offense for out-of-order top-level fields alongside with_options" do
       expect_offense(<<~RUBY)
         class UserType < BaseType
           field :z_field, String, null: true

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -443,12 +443,22 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
       RUBY
     end
 
-    it "does not register an offense for fields inside a with_options block regardless of order" do
-      expect_no_offenses(<<~RUBY)
+    it "registers an offense for out-of-order fields inside a with_options block" do
+      expect_offense(<<~RUBY)
         class UserType < BaseType
           with_options(access_scope: "internal") do
             field :z_field, String, null: true
             field :a_field, String, null: true
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `a_field` should appear before `z_field`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class UserType < BaseType
+          with_options(access_scope: "internal") do
+            field :a_field, String, null: true
+            field :z_field, String, null: true
           end
         end
       RUBY

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -429,4 +429,70 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
       end
     end
   end
+
+  context "when fields are inside a with_options block" do
+    it "does not register an offense comparing a with_options field against a top-level field" do
+      expect_no_offenses(<<~RUBY)
+        class UserType < BaseType
+          field :z_field, String, null: true
+
+          with_options(access_scope: "internal") do
+            field :a_field, String, null: true
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for fields inside a with_options block regardless of order" do
+      expect_no_offenses(<<~RUBY)
+        class UserType < BaseType
+          with_options(access_scope: "internal") do
+            field :z_field, String, null: true
+            field :a_field, String, null: true
+          end
+        end
+      RUBY
+    end
+
+    it "still registers an offense for out-of-order top-level fields alongside a with_options block" do
+      expect_offense(<<~RUBY)
+        class UserType < BaseType
+          field :z_field, String, null: true
+          field :a_field, String, null: true
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `a_field` should appear before `z_field`.
+
+          with_options(access_scope: "internal") do
+            field :b_field, String, null: true
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class UserType < BaseType
+          field :a_field, String, null: true
+          field :z_field, String, null: true
+
+          with_options(access_scope: "internal") do
+            field :b_field, String, null: true
+          end
+        end
+      RUBY
+    end
+
+    context "when the type is a module (interface)" do
+      it "does not register an offense comparing a with_options field against a top-level field" do
+        expect_no_offenses(<<~RUBY)
+          module UserInterface
+            include GraphQL::Schema::Interface
+
+            field :z_field, String, null: true
+
+            with_options(access_scope: "internal") do
+              field :a_field, String, null: true
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/graphql/ordered_fields_spec.rb
+++ b/spec/rubocop/cop/graphql/ordered_fields_spec.rb
@@ -360,4 +360,73 @@ RSpec.describe RuboCop::Cop::GraphQL::OrderedFields, :config do
       RUBY
     end
   end
+
+  context "when sibling classes are defined in the same module" do
+    it "does not register an offense for fields that are out of order across class boundaries" do
+      expect_no_offenses(<<~RUBY)
+        module Types
+          class AType < BaseType
+            field :z_field, String, null: true
+          end
+
+          class BType < BaseType
+            field :a_field, String, null: true
+          end
+        end
+      RUBY
+    end
+
+    it "still registers an offense for out-of-order fields within a single class" do
+      expect_offense(<<~RUBY)
+        module Types
+          class AType < BaseType
+            field :z_field, String, null: true
+            field :a_field, String, null: true
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fields should be sorted in an alphabetical order within their section. Field `a_field` should appear before `z_field`.
+          end
+
+          class BType < BaseType
+            field :b_field, String, null: true
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Types
+          class AType < BaseType
+            field :a_field, String, null: true
+            field :z_field, String, null: true
+          end
+
+          class BType < BaseType
+            field :b_field, String, null: true
+          end
+        end
+      RUBY
+    end
+
+    context "with Groups: false" do
+      let(:config) do
+        RuboCop::Config.new(
+          "GraphQL/OrderedFields" => {
+            "Groups" => false
+          }
+        )
+      end
+
+      it "does not register an offense for fields that are out of order across class boundaries" do
+        expect_no_offenses(<<~RUBY)
+          module Types
+            class AType < BaseType
+              field :z_field, String, null: true
+            end
+
+            class BType < BaseType
+              field :a_field, String, null: true
+            end
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Fix cross-boundary autocorrect: when \`on_module\` processed a module containing sibling/nested classes, \`def_node_search :field_declarations\` recursively found fields from all nested classes. The cop compared fields across class boundaries and autocorrect physically moved field source between unrelated classes.
- Fix \`with_options\` false positives: fields inside non-field blocks (e.g. \`with_options { field :foo }\`) were being compared against top-level fields. Autocorrect would move them out of the block, silently dropping shared options like \`access_scope\`.
- Fields inside non-field blocks are still checked for ordering *within* that block — only cross-boundary comparisons (block fields vs. top-level fields) are suppressed.

Both fixes compose: a \`direct_field_declarations\` helper scopes class-level ordering checks to fields that are direct children of the class; a new \`on_block\` handler runs the same ordering check for fields directly inside each non-field block.

Addresses the same root cause as #179.

## Test Plan

- [x] \`bundle exec rspec spec/rubocop/cop/graphql/ordered_fields_spec.rb\` — 23 examples, 0 failures
- [x] Verify no offense for fields in sibling classes inside a module (default and \`Groups: false\` config)
- [x] Verify no offense comparing a \`with_options\` field against a top-level field
- [x] Verify offense IS registered for out-of-order fields within the same \`with_options\` block
- [x] Verify ordering within a single class still enforced
- [x] Verify autocorrect on top-level fields leaves \`with_options\` block contents in place