### PR TITLE
ObjectDescription: only flag classes and modules that are actually GraphQL types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#187](https://github.com/DmitryTsepelev/rubocop-graphql/pull/187) `GraphQL/ObjectDescription` only flags classes and modules that are actually GraphQL types, instead of every class and every module with an `include` ([@corsonknowles][])
+
 ## 1.7.0 (2026-08-02)
 
 - [PR#185](https://github.com/DmitryTsepelev/rubocop-graphql/pull/185) Add `GraphQL/MethodShadowedByResolverMethod` cop: flags a `def` as dead code when `resolver:` and/or `resolver_method:` make the field call a different method instead ([@salzig][])
@@ -323,3 +325,4 @@
 [@amckinnie]: https://github.com/amckinnie
 [@salzig]: https://github.com/salzig
 
+[@corsonknowles]: https://github.com/corsonknowles

--- a/config/default.yml
+++ b/config/default.yml
@@ -148,6 +148,13 @@ GraphQL/ObjectDescription:
   Enabled: true
   VersionAdded: '0.3.0'
   Description: 'Ensures all types have a description'
+  # Skip the root operation types (Query, Mutation, Subscription), which are
+  # usually left undescribed. Set to false to require a description on them too.
+  IgnoreRootTypes: true
+  # Superclass (or included module) names to treat as GraphQL bases, on top of the
+  # conventional ones. Use when your base types are named unconventionally, e.g.
+  # `class Types::UserType < ApplicationType`.
+  AdditionalTypeBases: []
   Exclude:
     - "spec/**/*"
     - "test/**/*"

--- a/lib/rubocop/cop/graphql/object_description.rb
+++ b/lib/rubocop/cop/graphql/object_description.rb
@@ -6,6 +6,19 @@ module RuboCop
       #  This cop checks if a type (object, input, interface, scalar, union,
       #  mutation, subscription, and resolver) has a description.
       #
+      #  Only classes that actually declare a GraphQL type are checked: those whose
+      #  superclass resolves to a GraphQL base (`Object`, `InputObject`, `Union`,
+      #  `Enum`, `Scalar`, or anything ending in `Mutation`, `Subscription` or
+      #  `Resolver`), plus modules that `include` an `*Interface` base. Plain Ruby
+      #  classes that happen to live alongside types - error classes, analyzers,
+      #  validators, loaders, generators - are skipped, so they no longer need to be
+      #  silenced one by one.
+      #
+      #  Two kinds of real type declarations are also skipped, because neither
+      #  surfaces a description in the schema: abstract `Base*` types that other
+      #  types inherit from, and (unless `IgnoreRootTypes` is disabled) the root
+      #  operation types `Query`, `Mutation` and `Subscription`.
+      #
       # @example
       #   # good
       #
@@ -20,43 +33,184 @@ module RuboCop
       #     # ...
       #   end
       #
+      # @example
+      #   # good - not a GraphQL type, so no description is expected
+      #
+      #   class TrackingInfoNotAvailable < StandardError; end
+      #   class UserLoader < GraphQL::Batch::Loader; end
+      #
+      # @example
+      #   # good - abstract base and root operation types carry no description
+      #
+      #   class Types::BaseObject < GraphQL::Schema::Object; end
+      #   class Types::Query < Types::BaseObject; end
+      #
+      # @example AdditionalTypeBases: [] (default)
+      #   # good - `ApplicationType` is not a recognized GraphQL base, so this
+      #   # class is not checked
+      #
+      #   class Types::UserType < ApplicationType
+      #   end
+      #
+      # @example AdditionalTypeBases: ['ApplicationType']
+      #   # bad - `ApplicationType` is now treated as a GraphQL base
+      #
+      #   class Types::UserType < ApplicationType
+      #   end
+      #
       class ObjectDescription < Base
-        include RuboCop::GraphQL::NodePattern
         include RuboCop::GraphQL::DescriptionMethod
 
         MSG = "Missing type description"
 
-        # @!method interface?(node)
-        def_node_matcher :interface?, <<~PATTERN
-          (send nil? :include (const ...))
-        PATTERN
+        # Base class names that mark a GraphQL type when they match exactly, or with
+        # a `Base` prefix (`GraphQL::Schema::Object`, `Types::BaseObject`).
+        # Ambiguous words are deliberately not matched as suffixes, so a plain Ruby
+        # `ValueObject` base is not mistaken for a GraphQL one. `Interface` is absent
+        # on purpose: graphql-ruby interfaces are modules, so a *class* inheriting an
+        # `*::Interface` constant is always some other abstract base.
+        EXACT_BASES = %w[Object InputObject Union Enum Scalar].freeze
+
+        # These read unambiguously as GraphQL even inside a longer name, so they are
+        # matched as suffixes (`RelayClassicMutation`, `Base::PermissionedMutation`).
+        SUFFIX_BASES = %w[Mutation Subscription Resolver].freeze
+
+        # A base named exactly `Base` (`Resolvers::Base`) is only a GraphQL base when
+        # it sits in a namespace that says so.
+        GRAPHQL_NAMESPACES = %w[
+          Types Mutations Subscriptions Resolvers Inputs Interfaces Unions Enums Scalars
+        ].freeze
+
+        # GraphQL reserves these names for the root operation types.
+        ROOT_TYPE_NAMES = %w[Query Mutation Subscription].freeze
+
+        # `Base`, or `Base` followed by another word - the naming convention for the
+        # abstract types that other types inherit from (`BaseObject`, `BaseInterface`).
+        ABSTRACT_BASE_NAME = /\ABase(?:[A-Z]|\z)/
+
+        # Sorbet's `T` namespace is reserved, and `T::Enum` / `T::Struct` collide with
+        # the base names above.
+        SORBET_NAMESPACE = :T
 
         def on_class(node)
-          return if child_nodes(node).find { |child_node| has_description?(child_node) }
+          return unless graphql_type_class?(node)
+          return if exempt_type?(node)
+          return if described_or_root_named?(node)
 
           add_offense(node.identifier)
         end
 
         def on_module(node)
-          return if child_nodes(node).none? { |child_node| interface?(child_node) }
+          return if abstract_base?(node)
+          return unless undescribed_interface_module?(node)
 
-          if child_nodes(node).none? { |child_node| has_description?(child_node) }
-            add_offense(node.identifier)
-          end
+          add_offense(node.identifier)
         end
 
         private
 
-        def has_description?(node)
-          description_method_call?(node)
+        # Abstract bases and the root operation types are real GraphQL declarations,
+        # but neither surfaces a description in the schema.
+        def exempt_type?(node)
+          return true if abstract_base?(node)
+
+          ignore_root_types? && ROOT_TYPE_NAMES.include?(type_name(node))
         end
 
-        def child_nodes(node)
-          if node.body.instance_of? RuboCop::AST::Node
-            node.body.child_nodes
-          else
-            node.child_nodes
+        def abstract_base?(node)
+          ABSTRACT_BASE_NAME.match?(type_name(node))
+        end
+
+        def type_name(node)
+          node.identifier.short_name.to_s
+        end
+
+        def graphql_type_class?(node)
+          superclass = node.parent_class
+          return false if superclass.nil? || !superclass.const_type?
+          return false if superclass.namespace&.short_name == SORBET_NAMESPACE
+
+          graphql_base?(superclass)
+        end
+
+        def graphql_base?(const_node)
+          name = const_node.short_name.to_s
+          return true if additional_type_bases.include?(name)
+          return graphql_namespace?(const_node) if name == "Base"
+          return true if SUFFIX_BASES.any? { |suffix| name.end_with?(suffix) }
+
+          EXACT_BASES.include?(name.delete_prefix("Base"))
+        end
+
+        def graphql_namespace?(const_node)
+          namespace = const_node.namespace
+          return false if namespace.nil? || !namespace.const_type?
+
+          GRAPHQL_NAMESPACES.include?(namespace.short_name.to_s)
+        end
+
+        # A method call with no explicit receiver (e.g. `description "..."`,
+        # `include Foo`) - the shape of a GraphQL type DSL declaration.
+        def bare_call?(node)
+          node.send_type? && node.receiver.nil?
+        end
+
+        # Single pass over the module body: an interface module both `include`s an
+        # `*Interface` base and (when compliant) declares a `description`.
+        def undescribed_interface_module?(node)
+          interface = false
+          described = false
+
+          body_nodes(node).each do |child|
+            described ||= description_method_call?(child)
+            interface ||= interface_include?(child)
           end
+
+          interface && !described
+        end
+
+        def interface_include?(node)
+          return false unless bare_call?(node) && node.method?(:include)
+
+          arg = node.first_argument
+          return false unless arg&.const_type?
+
+          name = arg.short_name.to_s
+          name.end_with?("Interface") || additional_type_bases.include?(name)
+        end
+
+        # Single pass over the class body: a `description` satisfies the cop, and a
+        # `graphql_name "Query"` marks a root operation type declared under some
+        # other class name, which is exempt like a class named `Query` itself.
+        def described_or_root_named?(node)
+          body_nodes(node).any? do |child|
+            description_method_call?(child) || root_graphql_name?(child)
+          end
+        end
+
+        def root_graphql_name?(node)
+          return false unless ignore_root_types?
+          return false unless bare_call?(node) && node.method?(:graphql_name)
+
+          arg = node.first_argument
+          return false unless arg&.str_type?
+
+          ROOT_TYPE_NAMES.include?(arg.value)
+        end
+
+        def body_nodes(node)
+          body = node.body
+          return [] if body.nil?
+
+          body.begin_type? ? body.child_nodes : [body]
+        end
+
+        def ignore_root_types?
+          cop_config.fetch("IgnoreRootTypes", true)
+        end
+
+        def additional_type_bases
+          @additional_type_bases ||= Array(cop_config["AdditionalTypeBases"])
         end
       end
     end

--- a/spec/rubocop/cop/graphql/object_description_spec.rb
+++ b/spec/rubocop/cop/graphql/object_description_spec.rb
@@ -608,4 +608,276 @@ RSpec.describe RuboCop::Cop::GraphQL::ObjectDescription, :config do
       end
     end
   end
+
+  context "when the class is not a GraphQL type" do
+    it "does not register an offense for an error class" do
+      expect_no_offenses(<<~RUBY)
+        class TrackingInfoNotAvailable < StandardError; end
+      RUBY
+    end
+
+    it "does not register an offense for an error class nested in a mutation" do
+      expect_no_offenses(<<~RUBY)
+        class Mutations::ApplyPromotion < GraphQL::Schema::Resolver
+          description "Applies a promotion"
+
+          class OrderNotFound < Errors::PreconditionFailed; end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a query analyzer" do
+      expect_no_offenses(<<~RUBY)
+        class QueryDepthAnalyzer < GraphQL::Analysis::AST::Analyzer
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a schema validator" do
+      expect_no_offenses(<<~RUBY)
+        class PositiveNumberValidator < GraphQL::Schema::Validator
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a Rails generator" do
+      expect_no_offenses(<<~RUBY)
+        class MutationGenerator < Rails::Generators::NamedBase
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a batch loader" do
+      expect_no_offenses(<<~RUBY)
+        class UserLoader < GraphQL::Batch::Loader
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a custom connection" do
+      expect_no_offenses(<<~RUBY)
+        class UsersConnection < GraphQL::Pagination::Connection
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a Sorbet struct" do
+      expect_no_offenses(<<~RUBY)
+        class BackingObject < T::Struct
+          const :id, String
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a Sorbet enum" do
+      expect_no_offenses(<<~RUBY)
+        class IneligibleReason < T::Enum
+          enums do
+            Unknown = new("UNKNOWN")
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a class with no superclass" do
+      expect_no_offenses(<<~RUBY)
+        class UserPresenter
+          def call; end
+        end
+      RUBY
+    end
+
+    it "does not register an offense when the superclass is not a plain constant" do
+      expect_no_offenses(<<~RUBY)
+        class Point < Struct.new(:x, :y)
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a class inheriting a non-GraphQL `Interface` base" do
+      expect_no_offenses(<<~RUBY)
+        class BillsPaginatedQuery < Pagination::PaginatedApi::Interface
+        end
+      RUBY
+    end
+  end
+
+  context "when the type is an abstract base" do
+    it "does not register an offense for a base object" do
+      expect_no_offenses(<<~RUBY)
+        class BaseObject < GraphQL::Schema::Object
+          field :page_info, PageInfo, null: false
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a base named exactly Base" do
+      expect_no_offenses(<<~RUBY)
+        class Base < GraphQL::Schema::Object
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a base carrying a domain prefix" do
+      expect_no_offenses(<<~RUBY)
+        class BaseTimeOffMutation < Types::Base::Mutation
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a base interface module" do
+      expect_no_offenses(<<~RUBY)
+        module BaseInterface
+          include GraphQL::Schema::Interface
+        end
+      RUBY
+    end
+
+    it "registers an offense for a type whose name merely starts with the letters of Base" do
+      expect_offense(<<~RUBY)
+        class Basename < Types::Base::Object
+              ^^^^^^^^ Missing type description
+        end
+      RUBY
+    end
+  end
+
+  context "when the type is a root operation type" do
+    it "does not register an offense for Query" do
+      expect_no_offenses(<<~RUBY)
+        class Query < Types::BaseObject
+          field :users, [Types::UserType], null: false
+        end
+      RUBY
+    end
+
+    it "does not register an offense for Mutation" do
+      expect_no_offenses(<<~RUBY)
+        class Mutation < Types::BaseObject
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a root type renamed via graphql_name" do
+      expect_no_offenses(<<~RUBY)
+        class EmptyQuery < Types::BaseObject
+          graphql_name "Query"
+        end
+      RUBY
+    end
+
+    context "when IgnoreRootTypes is false" do
+      let(:cop_config) { { "IgnoreRootTypes" => false } }
+
+      it "registers an offense for Query" do
+        expect_offense(<<~RUBY)
+          class Query < Types::BaseObject
+                ^^^^^ Missing type description
+          end
+        RUBY
+      end
+
+      it "registers an offense for a root type renamed via graphql_name" do
+        expect_offense(<<~RUBY)
+          class EmptyQuery < Types::BaseObject
+                ^^^^^^^^^^ Missing type description
+            graphql_name "Query"
+          end
+        RUBY
+      end
+    end
+  end
+
+  context "when AdditionalTypeBases is configured" do
+    let(:cop_config) { { "AdditionalTypeBases" => %w[ApplicationType Describable] } }
+
+    it "registers an offense for a class inheriting a configured base" do
+      expect_offense(<<~RUBY)
+        class Types::UserType < ApplicationType
+              ^^^^^^^^^^^^^^^ Missing type description
+        end
+      RUBY
+    end
+
+    it "does not register an offense when that class has a description" do
+      expect_no_offenses(<<~RUBY)
+        class Types::UserType < ApplicationType
+          description "Represents application user"
+        end
+      RUBY
+    end
+
+    it "registers an offense for a module including a configured base" do
+      expect_offense(<<~RUBY)
+        module Types::Node
+               ^^^^^^^^^^^ Missing type description
+          include Describable
+        end
+      RUBY
+    end
+
+    it "still ignores unrelated bases" do
+      expect_no_offenses(<<~RUBY)
+        class UserPresenter < ApplicationPresenter
+        end
+      RUBY
+    end
+  end
+
+  context "when the module is not an interface" do
+    it "does not register an offense for a plain module" do
+      expect_no_offenses(<<~RUBY)
+        module Helpers
+          def self.call; end
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a module including a concern" do
+      expect_no_offenses(<<~RUBY)
+        module Helpers
+          include ActiveSupport::Concern
+        end
+      RUBY
+    end
+
+    it "does not register an offense for a module whose include has no argument" do
+      expect_no_offenses(<<~RUBY)
+        module Helpers
+          include
+        end
+      RUBY
+    end
+  end
+
+  context "when the interface module has other statements" do
+    it "registers an offense when a plain concern is included alongside the interface" do
+      expect_offense(<<~RUBY)
+        module Types::NodeInterface
+               ^^^^^^^^^^^^^^^^^^^^ Missing type description
+          include Helpers
+          include Types::BaseInterface
+        end
+      RUBY
+    end
+
+    it "does not register an offense when the description precedes the include" do
+      expect_no_offenses(<<~RUBY)
+        module Types::NodeInterface
+          description "An object with an ID"
+          include Types::BaseInterface
+        end
+      RUBY
+    end
+
+    it "registers an offense when `description` is called on an explicit receiver" do
+      expect_offense(<<~RUBY)
+        module Types::NodeInterface
+               ^^^^^^^^^^^^^^^^^^^^ Missing type description
+          include Types::BaseInterface
+          config.description "not the type description"
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #145 (and the recurring reports behind it: #42, #46, #95).

## The problem

`GraphQL/ObjectDescription` has no notion of what a GraphQL type is. `on_class` flags **every** class it visits, and `on_module` flags every module containing any `include SomeConst`. So anything that lives near your types gets reported:

```ruby
class TrackingInfoNotAvailable < StandardError; end       # offense
class QueryDepthAnalyzer < GraphQL::Analysis::AST::Analyzer; end  # offense
class PositiveNumberValidator < GraphQL::Schema::Validator; end   # offense
class MutationGenerator < Rails::Generators::NamedBase; end       # offense
class UserLoader < GraphQL::Batch::Loader; end            # offense
```

None of these respond to `description`. Today the only fixes are per-file `Exclude` entries and inline disables, both of which have to be maintained forever.

In #145 you suggested checking the base class rather than excluding files, and noted that a runtime check for `BaseDSLMethods` isn't possible from the AST. This PR is that suggestion, done by convention.

## The approach

A class is treated as a GraphQL type when its superclass resolves to a GraphQL base:

- exactly, or `Base`-prefixed: `Object`, `InputObject`, `Union`, `Enum`, `Scalar` — covering both `GraphQL::Schema::Object` and `Types::BaseObject`
- as a suffix: `Mutation`, `Subscription`, `Resolver` — these read unambiguously as GraphQL even inside a longer name (`RelayClassicMutation`)
- a base named exactly `Base` when it sits in a GraphQL namespace (`Resolvers::Base`, `Types::Base`)

A module is an interface when it `include`s an `*Interface`.

Deliberate exclusions:

- **`Interface` is not accepted as a class base.** graphql-ruby interfaces are modules, so a *class* inheriting an `*::Interface` constant is always some other abstract base.
- **`T::Enum` / `T::Struct`.** Sorbet's reserved `T` namespace collides with the base names above, so anything directly under it is skipped.

Two kinds of *real* type declarations are also skipped, since neither surfaces a description in the schema:

- abstract `Base*` types (`BaseObject`, `BaseTimeOffMutation`, a base named exactly `Base`) — note `Basename` is still flagged
- the root operation types `Query` / `Mutation` / `Subscription`, including ones declared under another class name via `graphql_name "Query"`

## Config

| Option | Default | Purpose |
| --- | --- | --- |
| `IgnoreRootTypes` | `true` | Skip the root operation types. Set to `false` to require descriptions on them. |
| `AdditionalTypeBases` | `[]` | Extra superclass / included-module names to treat as GraphQL bases, for codebases whose types don't follow the conventional naming (`class Types::UserType < ApplicationType`). |

`AdditionalTypeBases` exists because a narrower check has a real failure mode in the other direction: a codebase with unconventional base names would silently stop being covered. This gives those users a one-line opt back in.

**`IgnoreRootTypes: true` is the one opinionated default here** — it makes the cop quieter out of the box, but root types *can* legitimately carry a description. Happy to flip the default to `false` if you'd rather this PR be purely a false-positive fix.

## Compatibility

All 54 existing `object_description_spec` examples pass **unchanged** — resolvers, subscriptions, inputs, scalars, unions, interfaces, namespaced types and the `graphql_name` case all still behave as before. 32 new examples cover the fix; 21 of them fail against the current cop, confirming they're testing real behavior. Full suite: 363 examples, 0 failures. `rubocop` clean.

The behavior change is one-directional: strictly fewer offenses, except where `AdditionalTypeBases` is explicitly configured. Anyone currently carrying `Exclude` entries or inline disables for non-type classes can drop them.

## Also fixed: fragile body traversal

`child_nodes` branched on `node.body.instance_of?(RuboCop::AST::Node)`, which works only because `begin` is currently the one node type that maps to the plain `Node` class — every single-statement body gets a specialized subclass and falls through to the `node.child_nodes` branch, which happens to include the description. If rubocop-ast ever registers a `BeginNode` for `:begin`, every multi-statement class body would stop finding its description and the cop would report en masse. This now handles `nil`, `begin` and single-statement bodies explicitly.