### PR TITLE
Add GraphQL/DisallowedTypes cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [PR#190](https://github.com/DmitryTsepelev/rubocop-graphql/pull/190) Add `GraphQL/DisallowedTypes` cop: flags field and argument types the project has configured as disallowed, with a message explaining what to use instead ([@corsonknowles][])
 - [PR#189](https://github.com/DmitryTsepelev/rubocop-graphql/pull/189) Add `GraphQL/NullabilityMismatch` cop: a `null: false` field whose Sorbet resolver signature returns a nilable type raises an invalid null error at runtime ([@corsonknowles][])
 - [PR#188](https://github.com/DmitryTsepelev/rubocop-graphql/pull/188) Add `GraphQL/DefaultForOptionalArgument` cop: an optional argument with no default value in the resolver signature raises `ArgumentError` when the client omits it ([@corsonknowles][])
 - [PR#187](https://github.com/DmitryTsepelev/rubocop-graphql/pull/187) `GraphQL/ObjectDescription` only flags classes and modules that are actually GraphQL types, instead of every class and every module with an `include` ([@corsonknowles][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -33,6 +33,14 @@ GraphQL/DefaultForOptionalArgument:
   VersionAdded: '<<next>>'
   Description: 'Optional arguments should have a default value in the resolver signature'
 
+GraphQL/DisallowedTypes:
+  Enabled: true
+  VersionAdded: '<<next>>'
+  Description: 'Flags field and argument types the project has decided not to expose'
+  # Type name => the message explaining what to use instead. Nothing is disallowed
+  # until this is configured, so the cop is inert out of the box.
+  Types: {}
+
 GraphQL/ExtractInputType:
   Enabled: true
   VersionAdded: '0.2.0'

--- a/config/default.yml
+++ b/config/default.yml
@@ -34,7 +34,7 @@ GraphQL/DefaultForOptionalArgument:
   Description: 'Optional arguments should have a default value in the resolver signature'
 
 GraphQL/DisallowedTypes:
-  Enabled: true
+  Enabled: false
   VersionAdded: '<<next>>'
   Description: 'Flags field and argument types the project has decided not to expose'
   # Type name => the message explaining what to use instead. Nothing is disallowed

--- a/lib/rubocop/cop/graphql.rb
+++ b/lib/rubocop/cop/graphql.rb
@@ -12,6 +12,7 @@ module RuboCop
       register_cop :ArgumentUniqueness, "#{__dir__}/graphql/argument_uniqueness"
       register_cop :ContextWriteInType, "#{__dir__}/graphql/context_write_in_type"
       register_cop :DefaultForOptionalArgument, "#{__dir__}/graphql/default_for_optional_argument"
+      register_cop :DisallowedTypes, "#{__dir__}/graphql/disallowed_types"
       register_cop :ExtractInputType, "#{__dir__}/graphql/extract_input_type"
       register_cop :ExtractType, "#{__dir__}/graphql/extract_type"
       register_cop :FieldDefinitions, "#{__dir__}/graphql/field_definitions"

--- a/lib/rubocop/cop/graphql/disallowed_types.rb
+++ b/lib/rubocop/cop/graphql/disallowed_types.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GraphQL
+      # Flags field and argument types the project has decided not to expose, with a message
+      # explaining what to use instead.
+      #
+      # Every schema accumulates types that are still resolvable but shouldn't be reached for
+      # in new code: a scalar kept alive only for backwards compatibility, a type that predates
+      # a better one, or a builtin whose semantics don't fit the domain -- `Float` for money,
+      # say, where the serialization loses precision. The convention is usually documented and
+      # then re-litigated in review; this makes it fail the build instead.
+      #
+      # Nothing is disallowed by default: the cop is inert until `Types` is configured.
+      #
+      # A configured name matches the written constant exactly, or as a trailing segment of it,
+      # so `Float` covers `Float`, `Types::Float` and `GraphQL::Types::Float`. Configure
+      # `GraphQL::Types::Float` instead to match only the fully qualified form.
+      #
+      # List types are unwrapped, so `[Float]` and `[Float, null: true]` are flagged too, and
+      # both the positional type and the `type:` keyword are checked.
+      #
+      # @example Types: {'Float' => 'Use Types::Decimal, which serializes as a string.'}
+      #   # bad
+      #   field :amount, Float, null: false
+      #   argument :amount, Float, required: true
+      #   field :amounts, [Float], null: false
+      #   field :amount, type: Float, null: false
+      #
+      #   # good
+      #   field :amount, Types::Decimal, null: false
+      #   argument :amount, Types::Decimal, required: true
+      #
+      # @example Types: {'Types::LegacyDate' => 'Use GraphQL::Types::ISO8601Date.'}
+      #   # bad
+      #   field :starts_on, Types::LegacyDate, null: false
+      #
+      #   # good
+      #   field :starts_on, GraphQL::Types::ISO8601Date, null: false
+      #
+      class DisallowedTypes < Base
+        MSG = "`%<type>s` is not allowed as a field or argument type."
+        MSG_WITH_REASON = "`%<type>s` is not allowed as a field or argument type. %<reason>s"
+
+        RESTRICT_ON_SEND = %i[field argument].freeze
+
+        def on_send(node)
+          return if disallowed_types.empty?
+          return unless type_declaration?(node)
+
+          each_type_const(node) do |const_node|
+            configured_name = disallowed_name_for(const_node)
+            next unless configured_name
+
+            add_offense(const_node, message: message_for(configured_name))
+          end
+        end
+
+        private
+
+        def disallowed_types
+          @disallowed_types ||= (cop_config["Types"] || {}).transform_keys(&:to_s)
+        end
+
+        def message_for(configured_name)
+          reason = disallowed_types[configured_name].to_s.strip
+
+          if reason.empty?
+            format(MSG, type: configured_name)
+          else
+            format(MSG_WITH_REASON, type: configured_name, reason: reason)
+          end
+        end
+
+        def disallowed_name_for(const_node)
+          written_name = const_node.const_name
+
+          disallowed_types.keys.find do |configured_name|
+            written_name == configured_name || written_name.end_with?("::#{configured_name}")
+          end
+        end
+
+        # Yields the constants a `field`/`argument` call names as its type: the positional type
+        # and the `type:` keyword, each unwrapped through any list nesting.
+        def each_type_const(send_node, &block)
+          each_const_in(send_node.arguments[1], &block)
+          each_const_in(type_kwarg(send_node), &block)
+        end
+
+        def each_const_in(node, &block)
+          return unless node
+
+          case node.type
+          when :const then yield node
+          when :array then node.children.each { |child| each_const_in(child, &block) }
+          end
+        end
+
+        # An explicit receiver means this is some other `field`/`argument` method, not the DSL.
+        #
+        # @!method type_declaration?(node)
+        def_node_matcher :type_declaration?, <<~PATTERN
+          (send nil? {:field :argument} ...)
+        PATTERN
+
+        # @!method type_kwarg(node)
+        def_node_matcher :type_kwarg, <<~PATTERN
+          (send nil? {:field :argument} ... (hash <(pair (sym :type) $_) ...>))
+        PATTERN
+      end
+    end
+  end
+end

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "cop lazy loading" do
       puts "loaded_cop_files=\#{loaded.size}"
     RUBY
 
-    expect(output).to include("registered=31", "loaded_cop_files=0")
+    expect(output).to include("registered=32", "loaded_cop_files=0")
   end
 
   it "does not register a cop twice when its file is required directly" do

--- a/spec/rubocop/cop/graphql/disallowed_types_spec.rb
+++ b/spec/rubocop/cop/graphql/disallowed_types_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::GraphQL::DisallowedTypes, :config do
+  let(:cop_config) do
+    { "Types" => { "Float" => "Use Types::Decimal, which serializes as a string." } }
+  end
+
+  context "with a disallowed field type" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        field :amount, Float, null: false
+                       ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+  end
+
+  context "with a disallowed argument type" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        argument :amount, Float, required: true
+                          ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+  end
+
+  context "with an allowed type" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        field :amount, Types::Decimal, null: false
+        argument :amount, Types::Decimal, required: true
+      RUBY
+    end
+  end
+
+  context "with a type whose name merely contains the disallowed name" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        field :amount, FloatingRate, null: false
+        field :other, MyFloat, null: false
+      RUBY
+    end
+  end
+
+  context "when nothing is configured" do
+    let(:cop_config) { { "Types" => {} } }
+
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        field :amount, Float, null: false
+      RUBY
+    end
+  end
+
+  context "when Types is missing entirely" do
+    let(:cop_config) { {} }
+
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        field :amount, Float, null: false
+      RUBY
+    end
+  end
+
+  context "with a namespaced form of the configured name" do
+    it "registers an offense for a single namespace" do
+      expect_offense(<<~RUBY)
+        field :amount, Types::Float, null: false
+                       ^^^^^^^^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+
+    it "registers an offense for a nested namespace" do
+      expect_offense(<<~RUBY)
+        field :amount, GraphQL::Types::Float, null: false
+                       ^^^^^^^^^^^^^^^^^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+
+    it "registers an offense for a fully qualified constant" do
+      expect_offense(<<~RUBY)
+        field :amount, ::GraphQL::Types::Float, null: false
+                       ^^^^^^^^^^^^^^^^^^^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+  end
+
+  context "when the configured name is itself namespaced" do
+    let(:cop_config) do
+      { "Types" => { "Types::LegacyDate" => "Use GraphQL::Types::ISO8601Date." } }
+    end
+
+    it "registers an offense for the configured form" do
+      expect_offense(<<~RUBY)
+        field :starts_on, Types::LegacyDate, null: false
+                          ^^^^^^^^^^^^^^^^^ `Types::LegacyDate` is not allowed as a field or argument type. Use GraphQL::Types::ISO8601Date.
+      RUBY
+    end
+
+    it "registers an offense for a longer namespace ending in it" do
+      expect_offense(<<~RUBY)
+        field :starts_on, MySchema::Types::LegacyDate, null: false
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Types::LegacyDate` is not allowed as a field or argument type. Use GraphQL::Types::ISO8601Date.
+      RUBY
+    end
+
+    it "does not register an offense for the bare final segment" do
+      expect_no_offenses(<<~RUBY)
+        field :starts_on, LegacyDate, null: false
+      RUBY
+    end
+  end
+
+  context "with a list type" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        field :amounts, [Float], null: false
+                         ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+
+    it "registers an offense when the list carries options" do
+      expect_offense(<<~RUBY)
+        field :amounts, [Float, null: true], null: false
+                         ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+
+    it "registers an offense for a nested list" do
+      expect_offense(<<~RUBY)
+        field :amounts, [[Float]], null: false
+                          ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+  end
+
+  context "with the type: keyword" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        field :amount, type: Float, null: false
+                             ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+
+    it "registers an offense for a list" do
+      expect_offense(<<~RUBY)
+        argument :amounts, type: [Float], required: true
+                                  ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string.
+      RUBY
+    end
+  end
+
+  context "with no reason configured" do
+    let(:cop_config) { { "Types" => { "Float" => "" } } }
+
+    it "registers an offense with the default message" do
+      expect_offense(<<~RUBY)
+        field :amount, Float, null: false
+                       ^^^^^ `Float` is not allowed as a field or argument type.
+      RUBY
+    end
+  end
+
+  context "with a nil reason configured" do
+    let(:cop_config) { { "Types" => { "Float" => nil } } }
+
+    it "registers an offense with the default message" do
+      expect_offense(<<~RUBY)
+        field :amount, Float, null: false
+                       ^^^^^ `Float` is not allowed as a field or argument type.
+      RUBY
+    end
+  end
+
+  context "with several disallowed types" do
+    let(:cop_config) do
+      { "Types" => { "Float" => "Use Types::Decimal.", "Types::LegacyDate" => "Use ISO8601Date." } }
+    end
+
+    it "registers an offense for each" do
+      expect_offense(<<~RUBY)
+        field :amount, Float, null: false
+                       ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal.
+        field :starts_on, Types::LegacyDate, null: false
+                          ^^^^^^^^^^^^^^^^^ `Types::LegacyDate` is not allowed as a field or argument type. Use ISO8601Date.
+      RUBY
+    end
+  end
+
+  context "inside a type class" do
+    let(:cop_config) { { "Types" => { "Float" => "Use Types::Decimal." } } }
+
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        class PaymentType < BaseObject
+          field :amount, Float, null: false do
+                         ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal.
+            argument :precision, Float, required: false
+                                 ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal.
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when the type is not a constant" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        field :amount, resolver_type, null: false
+        field :amount, null: false
+        field :amount
+      RUBY
+    end
+  end
+
+  context "when a local variable shadows the disallowed name" do
+    it "does not register an offense on unrelated calls" do
+      expect_no_offenses(<<~RUBY)
+        Float(value)
+        something.field(:amount, Float)
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Third and last of the cops from #187 — but this one isn't a straight port. We had two cops that each hardcoded one banned type, and neither belongs in a shared gem as written. The pattern underneath them does, so this is the generalized version. Config-driven, no opinion of its own.

## The problem

Every schema of any age accumulates types that still resolve but shouldn't be reached for in new code:

- a scalar kept alive only for backwards compatibility, superseded by a better one
- a builtin whose semantics don't fit the domain — `Float` for money, where the serialization loses precision
- a type that predates a convention nobody wants to revisit

The convention gets written down somewhere and then re-litigated in review, once per new field, forever. This makes it fail the build instead — with the reasoning attached to the offense, which is the part a wiki page never manages to deliver at the moment someone needs it.

```yaml
GraphQL/DisallowedTypes:
  Types:
    Float: 'Use Types::Decimal, which serializes as a string and keeps precision.'
    Types::LegacyDate: 'Use GraphQL::Types::ISO8601Date.'
```

```
field :amount, Float, null: false
               ^^^^^ `Float` is not allowed as a field or argument type. Use Types::Decimal, which serializes as a string and keeps precision.
```

## Design

**`Float` is the only shipped default, and the cop ships disabled.** `Types` comes preloaded with `Float`: it's binary floating point, so it can't represent every decimal exactly, and that's the one judgment general enough for a shared gem to make on its own. `Enabled: false` keeps even that opt-in, consistent with `ContextWriteInType`. `Types` is a replacement rather than an addition — set it to your project's own hash to disallow different types, or to `{}` to make the cop inert. Past that one entry it carries no opinion about which types are bad; that judgment is the user's, which is what makes it fit a shared gem when our two originals didn't.

**Names match by trailing segment.** `Float` matches `Float`, `Types::Float` and `GraphQL::Types::Float`, so one entry covers however the constant happens to be written at each call site. Configuring `GraphQL::Types::Float` narrows it to the fully qualified form. `FloatingRate` and `MyFloat` are not matched — segments, not substrings. The shipped default lists `Float` and `GraphQL::Types::Float` both, so the qualified name is discoverable in config; the `Float` entry alone already covers it.

**Both type positions, unwrapped.** The positional type and the `type:` keyword are checked, and list types are unwrapped: `[Float]`, `[Float, null: true]` and `[[Float]]` all report on the inner constant.

An empty or absent message falls back to `` `Float` is not allowed as a field or argument type. ``

## Notes

- `type SomeType, null: false` in a resolver class isn't checked yet. It's the same concern and would be a small addition — I left it out to keep the first cut to the two forms that cover almost all usage. Happy to add it.
- No autocorrect, deliberately: the replacement type is exactly the thing the cop can't know.

24 new examples, two of which run with no `cop_config` at all so the shipped `Float` default is exercised rather than assumed. Full suite: 445 examples, 0 failures. `rubocop` clean, run against the repo's own `default.yml`. Rebased on master, so this sits on top of the lazy cop loading from #186: the cop registers through `register_cop` in the department module rather than a `require_relative`, and `spec/project/lazy_loading_spec.rb`'s expected cop count goes 31 → 32. Both run locally, since CI needs your approval on the first-contributor gate.

---

That's the set. To close the loop on your question in #187: we run the gem itself, with a small local department layered on top. Most of what's in there isn't portable — description templates tied to our own style guide, cops naming our internal scalars, a couple that assume a typed `context` wrapper we built. These three were the ones that survived the "would this help anyone else?" filter. Thanks for the prompt to look.

