### PR TITLE
FieldDescription: skip fields built from a resolver class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [PR#191](https://github.com/DmitryTsepelev/rubocop-graphql/pull/191) `GraphQL/FieldDescription` no longer flags fields built from a resolver, mutation or subscription class, which inherit that class's description ([@corsonknowles][])
 - [PR#189](https://github.com/DmitryTsepelev/rubocop-graphql/pull/189) Add `GraphQL/NullabilityMismatch` cop: a `null: false` field whose Sorbet resolver signature returns a nilable type raises an invalid null error at runtime ([@corsonknowles][])
 - [PR#188](https://github.com/DmitryTsepelev/rubocop-graphql/pull/188) Add `GraphQL/DefaultForOptionalArgument` cop: an optional argument with no default value in the resolver signature raises `ArgumentError` when the client omits it ([@corsonknowles][])
 - [PR#187](https://github.com/DmitryTsepelev/rubocop-graphql/pull/187) `GraphQL/ObjectDescription` only flags classes and modules that are actually GraphQL types, instead of every class and every module with an `include` ([@corsonknowles][])

--- a/lib/rubocop/cop/graphql/field_description.rb
+++ b/lib/rubocop/cop/graphql/field_description.rb
@@ -18,6 +18,16 @@ module RuboCop
       #     field :name, String, null: true
       #   end
       #
+      # Fields built from a resolver, mutation or subscription class are not
+      # flagged: graphql-ruby takes their description from that class.
+      #
+      # @example
+      #   # good
+      #
+      #   class UserType < BaseType
+      #     field :posts, resolver: PostsResolver
+      #   end
+      #
       class FieldDescription < Base
         include RuboCop::GraphQL::NodePattern
 
@@ -28,6 +38,7 @@ module RuboCop
           return unless field_definition?(node)
 
           field = RuboCop::GraphQL::Field.new(node)
+          return if field.kwargs.resolver_class
 
           add_offense(node) unless field.description
         end

--- a/lib/rubocop/graphql/field/kwargs.rb
+++ b/lib/rubocop/graphql/field/kwargs.rb
@@ -21,6 +21,16 @@ module RuboCop
           (pair (sym :resolver) ...)
         PATTERN
 
+        # @!method mutation_kwarg?(node)
+        def_node_matcher :mutation_kwarg?, <<~PATTERN
+          (pair (sym :mutation) ...)
+        PATTERN
+
+        # @!method subscription_kwarg?(node)
+        def_node_matcher :subscription_kwarg?, <<~PATTERN
+          (pair (sym :subscription) ...)
+        PATTERN
+
         # @!method method_kwarg?(node)
         def_node_matcher :method_kwarg?, <<~PATTERN
           (pair (sym :method) ...)
@@ -57,6 +67,20 @@ module RuboCop
 
         def resolver
           @nodes.find { |kwarg| resolver_kwarg?(kwarg) }
+        end
+
+        def mutation
+          @nodes.find { |kwarg| mutation_kwarg?(kwarg) }
+        end
+
+        def subscription
+          @nodes.find { |kwarg| subscription_kwarg?(kwarg) }
+        end
+
+        # graphql-ruby builds the field's resolver class out of any one of these
+        # options, and the field then inherits configuration from that class.
+        def resolver_class
+          resolver || mutation || subscription
         end
 
         def method

--- a/spec/rubocop/cop/graphql/field_description_spec.rb
+++ b/spec/rubocop/cop/graphql/field_description_spec.rb
@@ -129,6 +129,46 @@ RSpec.describe RuboCop::Cop::GraphQL::FieldDescription, :config do
     end
   end
 
+  context "when field is built from a resolver class" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class UserType < BaseType
+          field :posts, resolver: PostsResolver
+        end
+      RUBY
+    end
+
+    it "not registers an offense when the field also has a block" do
+      expect_no_offenses(<<~RUBY)
+        class UserType < BaseType
+          field :posts, resolver: PostsResolver do
+            argument :short, Boolean, required: false
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when field is built from a mutation class" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class MutationType < BaseType
+          field :create_post, mutation: Mutations::CreatePost
+        end
+      RUBY
+    end
+  end
+
+  context "when field is built from a subscription class" do
+    it "not registers an offense" do
+      expect_no_offenses(<<~RUBY)
+        class SubscriptionType < BaseType
+          field :post_added, subscription: Subscriptions::PostAdded
+        end
+      RUBY
+    end
+  end
+
   it "registers an offense" do
     expect_offense(<<~RUBY)
       class UserType < BaseType


### PR DESCRIPTION
`GraphQL/FieldDescription` flags fields that do have a description.

graphql-ruby collapses `resolver:`, `mutation:` and `subscription:` into the field's resolver class:

```ruby
# lib/graphql/schema/member/has_fields.rb
if (resolver_class = resolver || mutation || subscription)
  kwargs[:resolver_class] = resolver_class
```

and `Schema::Field#description` falls back to it:

```ruby
# lib/graphql/schema/field.rb
@resolver_class.description
```

So this is fine, and the description shows up in the emitted SDL — but the cop reports `Missing field description`:

```ruby
class UserType < BaseType
  field :posts, resolver: PostsResolver
end

class PostsResolver < GraphQL::Schema::Resolver
  description "The user's posts"
  type [PostType], null: false
end
```

This PR skips those fields. `Field::Kwargs` gains `mutation`, `subscription` and a `resolver_class` helper that mirrors graphql-ruby's own precedence, which is what the cop checks. That matches how `DefaultForOptionalArgument` and `NullabilityMismatch` already bow out when a field delegates to a resolver.

The cop can't see whether the resolver class actually sets a description — it usually lives in another file — so skipping is the conservative call, same as the existing cops.

Found while burning down ~130 real `FieldDescription` offenses in a large federated schema; these two were the only false positives in the repo.

`bundle exec rspec` (425 examples) and `bundle exec rubocop` are green locally. CI shows `action_required` for me as a non-member, so it won't report until you approve the run.