### PR TITLE
ObjectDescription: allow configuring additional GraphQL base suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#192](https://github.com/DmitryTsepelev/rubocop-graphql/pull/192) `GraphQL/ObjectDescription` accepts an `AdditionalTypeBaseSuffixes` option, for projects whose GraphQL base classes share a suffix that is ambiguous by default such as `Object` ([@corsonknowles][])
+
 ## 1.8.0 (2026-08-20)
 
 - [PR#191](https://github.com/DmitryTsepelev/rubocop-graphql/pull/191) `GraphQL/FieldDescription` no longer flags fields built from a resolver, mutation or subscription class, which inherit that class's description ([@corsonknowles][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -173,6 +173,10 @@ GraphQL/ObjectDescription:
   # conventional ones. Use when your base types are named unconventionally, e.g.
   # `class Types::UserType < ApplicationType`.
   AdditionalTypeBases: []
+  # Suffixes to treat as GraphQL bases, on top of Mutation, Subscription and
+  # Resolver. Use when your base types share a suffix that is ambiguous by default,
+  # e.g. `Object` for `class Types::UserType < PermissionedObject`.
+  AdditionalTypeBaseSuffixes: []
   Exclude:
     - "spec/**/*"
     - "test/**/*"

--- a/lib/rubocop/cop/graphql/object_description.rb
+++ b/lib/rubocop/cop/graphql/object_description.rb
@@ -58,6 +58,20 @@ module RuboCop
       #   class Types::UserType < ApplicationType
       #   end
       #
+      # @example AdditionalTypeBaseSuffixes: [] (default)
+      #   # good - only `Object` exactly, or with a `Base` prefix, is a recognized
+      #   # object base, so a plain Ruby `ValueObject` is not mistaken for one
+      #
+      #   class Money < ValueObject
+      #   end
+      #
+      # @example AdditionalTypeBaseSuffixes: ['Object']
+      #   # bad - every base whose name ends in `Object` is now treated as a GraphQL
+      #   # base, which suits an app whose bases carry a domain prefix
+      #
+      #   class Types::UserType < PermissionedObject
+      #   end
+      #
       class ObjectDescription < Base
         include RuboCop::GraphQL::DescriptionMethod
 
@@ -66,13 +80,15 @@ module RuboCop
         # Base class names that mark a GraphQL type when they match exactly, or with
         # a `Base` prefix (`GraphQL::Schema::Object`, `Types::BaseObject`).
         # Ambiguous words are deliberately not matched as suffixes, so a plain Ruby
-        # `ValueObject` base is not mistaken for a GraphQL one. `Interface` is absent
-        # on purpose: graphql-ruby interfaces are modules, so a *class* inheriting an
-        # `*::Interface` constant is always some other abstract base.
+        # `ValueObject` base is not mistaken for a GraphQL one; an app whose own bases
+        # do carry such a suffix opts in via `AdditionalTypeBaseSuffixes`. `Interface`
+        # is absent on purpose: graphql-ruby interfaces are modules, so a *class*
+        # inheriting an `*::Interface` constant is always some other abstract base.
         EXACT_BASES = %w[Object InputObject Union Enum Scalar].freeze
 
         # These read unambiguously as GraphQL even inside a longer name, so they are
         # matched as suffixes (`RelayClassicMutation`, `Base::PermissionedMutation`).
+        # `AdditionalTypeBaseSuffixes` extends this list per app.
         SUFFIX_BASES = %w[Mutation Subscription Resolver].freeze
 
         # A base named exactly `Base` (`Resolvers::Base`) is only a GraphQL base when
@@ -137,7 +153,7 @@ module RuboCop
           name = const_node.short_name.to_s
           return true if additional_type_bases.include?(name)
           return graphql_namespace?(const_node) if name == "Base"
-          return true if SUFFIX_BASES.any? { |suffix| name.end_with?(suffix) }
+          return true if name.end_with?(*SUFFIX_BASES, *additional_type_base_suffixes)
 
           EXACT_BASES.include?(name.delete_prefix("Base"))
         end
@@ -176,7 +192,9 @@ module RuboCop
           return false unless arg&.const_type?
 
           name = arg.short_name.to_s
-          name.end_with?("Interface") || additional_type_bases.include?(name)
+          return true if additional_type_bases.include?(name)
+
+          name.end_with?("Interface", *additional_type_base_suffixes)
         end
 
         # Single pass over the class body: a `description` satisfies the cop, and a
@@ -211,6 +229,10 @@ module RuboCop
 
         def additional_type_bases
           @additional_type_bases ||= Array(cop_config["AdditionalTypeBases"])
+        end
+
+        def additional_type_base_suffixes
+          @additional_type_base_suffixes ||= Array(cop_config["AdditionalTypeBaseSuffixes"])
         end
       end
     end

--- a/spec/rubocop/cop/graphql/object_description_spec.rb
+++ b/spec/rubocop/cop/graphql/object_description_spec.rb
@@ -824,6 +824,73 @@ RSpec.describe RuboCop::Cop::GraphQL::ObjectDescription, :config do
     end
   end
 
+  context "when AdditionalTypeBaseSuffixes is not configured" do
+    it "does not register an offense for a plain Ruby base ending in Object" do
+      expect_no_offenses(<<~RUBY)
+        class Money < ValueObject
+        end
+      RUBY
+    end
+  end
+
+  context "when AdditionalTypeBaseSuffixes is configured" do
+    let(:cop_config) { { "AdditionalTypeBaseSuffixes" => %w[Object] } }
+
+    it "registers an offense for a class inheriting a base with that suffix" do
+      expect_offense(<<~RUBY)
+        class Types::UserType < PermissionedObject
+              ^^^^^^^^^^^^^^^ Missing type description
+        end
+      RUBY
+    end
+
+    it "registers an offense for a namespaced base with that suffix" do
+      expect_offense(<<~RUBY)
+        class Savings < Base::BankingBridge::AuthorizedObject
+              ^^^^^^^ Missing type description
+        end
+      RUBY
+    end
+
+    it "does not register an offense when that class has a description" do
+      expect_no_offenses(<<~RUBY)
+        class Types::UserType < PermissionedObject
+          description "Represents application user"
+        end
+      RUBY
+    end
+
+    it "registers an offense for a module including a base with that suffix" do
+      expect_offense(<<~RUBY)
+        module Types::Node
+               ^^^^^^^^^^^ Missing type description
+          include SharedObject
+        end
+      RUBY
+    end
+
+    it "still ignores bases without that suffix" do
+      expect_no_offenses(<<~RUBY)
+        class UserPresenter < ApplicationPresenter
+        end
+      RUBY
+    end
+
+    it "still ignores an abstract base carrying that suffix" do
+      expect_no_offenses(<<~RUBY)
+        class BasePermissionedObject < GraphQL::Schema::Object
+        end
+      RUBY
+    end
+
+    it "still ignores a Sorbet base whose name ends in that suffix" do
+      expect_no_offenses(<<~RUBY)
+        class Money < T::ValueObject
+        end
+      RUBY
+    end
+  end
+
   context "when the module is not an interface" do
     it "does not register an offense for a plain module" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
### The gap

`AdditionalTypeBases` (#187) handles a base with an unconventional *name*. It matches exactly, though, so an app whose bases all share a *suffix* has to enumerate every one — and keeps having to, as new ones appear. In the schema I maintain that list is six entries:

```
PermissionedObject  AuthorizedObject  SharedPermissionedObject
SharedObject  VendorPreferencePermissionedObject  BookkeepingSubgraphPermissionedObject
```

All six mean "GraphQL object base". The seventh someone adds tomorrow silently goes unchecked, which is the failure mode `AdditionalTypeBases` can't express.

### Why not just suffix-match `Object`

Because the existing default is right. `Mutation`, `Subscription` and `Resolver` are matched as suffixes since they read unambiguously as GraphQL; `Object` is deliberately excluded so a plain Ruby `ValueObject` base isn't mistaken for a GraphQL one. I'd rather not spend everyone's false-positive budget on my naming convention.

So this is opt-in: `AdditionalTypeBaseSuffixes`, default `[]`. No existing configuration changes behaviour.

```yaml
GraphQL/ObjectDescription:
  AdditionalTypeBaseSuffixes: ['Object']
```

### Behaviour

It composes with the guards already in place rather than bypassing them — with `['Object']` configured, all of these are still skipped:

| code | why |
|---|---|
| `class BasePermissionedObject < GraphQL::Schema::Object` | abstract `Base*` type |
| `class Money < T::ValueObject` | Sorbet's `T` namespace |
| `class UserPresenter < ApplicationPresenter` | suffix doesn't match |

And it applies to included modules too, matching how `AdditionalTypeBases` already behaves.

One thing worth calling out: the `ValueObject` guarantee in the `EXACT_BASES` comment was only ever a comment. It now has a spec, so the default can't drift.

### Verification

CI needs maintainer approval for my runs, so locally on this branch:

- `bundle _2.7.2_ exec rspec` — **456 examples, 0 failures** (86 → 94 in `object_description_spec.rb`)
- `bundle _2.7.2_ exec rubocop` — **98 files inspected, no offenses**

I also confirmed the three positive examples fail without the `lib/` change, so they're pinning the new behaviour rather than passing vacuously.
